### PR TITLE
Optional move confirmation

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -29,7 +29,7 @@
 }
 
 #ssb-chess-settings-dialog-close {
-  text-align: center;
+  margin: auto;
   display: block;
 }
 

--- a/css/global.css
+++ b/css/global.css
@@ -17,14 +17,20 @@
   background-color: white;
   position: absolute;
   z-index: 500;
-  top: 50%;
+  top: 30%;
   left: 50%;
-  height: 150px;
+  height: 100px;
   width: 300px;
 }
 
 #ssb-chess-dialog-checkbox-container {
-  margin: auto;
+  margin: 5px;
+  text-align: center;
+}
+
+#ssb-chess-settings-dialog-close {
+  text-align: center;
+  display: block;
 }
 
 #ssb-chess-settings-nav-item {

--- a/css/global.css
+++ b/css/global.css
@@ -12,3 +12,17 @@
   width: 100%;
   overflow: scroll;
 }
+
+#ssb-chess-settings-dialog {
+  background-color: white;
+  position: absolute;
+  z-index: 500;
+  top: 50%;
+  left: 50%;
+  height: 150px;
+  width: 300px;
+}
+
+#ssb-chess-dialog-checkbox-container {
+  margin: auto;
+}

--- a/css/global.css
+++ b/css/global.css
@@ -26,3 +26,8 @@
 #ssb-chess-dialog-checkbox-container {
   margin: auto;
 }
+
+#ssb-chess-settings-nav-item {
+  float: right;
+  margin-right: 10px;
+}

--- a/ctrl/game_move.js
+++ b/ctrl/game_move.js
@@ -6,37 +6,33 @@ module.exports = (gameSSBDao, myIdent) => {
   const chessWorker = new Worker(rootDir + 'vendor/scalachessjs/scalachess.js');
 
   function makeMove(gameRootMessage, originSquare, destinationSquare, promoteTo) {
-    console.log(gameRootMessage);
-    console.log(originSquare);
-    console.log(destinationSquare);
-    console.log(promoteTo);
 
-    // gameSSBDao.getSituation(gameRootMessage).then(situation => {
-    //   if (situation.toMove !== myIdent) {
-    //     console.log("Not " + myIdent + " to move");
-    //   } else {
-    //
-    //     const pgnMoves = situation.pgnMoves;
-    //     chessWorker.postMessage({
-    //       'topic': 'move',
-    //       'payload': {
-    //         'fen': situation.fen,
-    //         'pgnMoves': pgnMoves,
-    //         'orig': originSquare,
-    //         'dest': destinationSquare,
-    //         'promotion': promoteTo
-    //       },
-    //       reqid: {
-    //         gameRootMessage: gameRootMessage,
-    //         originSquare: originSquare,
-    //         destinationSquare: destinationSquare,
-    //         players: situation.players
-    //       }
-    //
-    //     });
-    //
-    //   }
-    // });
+    gameSSBDao.getSituation(gameRootMessage).then(situation => {
+      if (situation.toMove !== myIdent) {
+        console.log("Not " + myIdent + " to move");
+      } else {
+
+        const pgnMoves = situation.pgnMoves;
+        chessWorker.postMessage({
+          'topic': 'move',
+          'payload': {
+            'fen': situation.fen,
+            'pgnMoves': pgnMoves,
+            'orig': originSquare,
+            'dest': destinationSquare,
+            'promotion': promoteTo
+          },
+          reqid: {
+            gameRootMessage: gameRootMessage,
+            originSquare: originSquare,
+            destinationSquare: destinationSquare,
+            players: situation.players
+          }
+
+        });
+
+      }
+    });
   }
 
   function resignGame(gameId) {

--- a/ctrl/game_move.js
+++ b/ctrl/game_move.js
@@ -6,33 +6,37 @@ module.exports = (gameSSBDao, myIdent) => {
   const chessWorker = new Worker(rootDir + 'vendor/scalachessjs/scalachess.js');
 
   function makeMove(gameRootMessage, originSquare, destinationSquare, promoteTo) {
+    console.log(gameRootMessage);
+    console.log(originSquare);
+    console.log(destinationSquare);
+    console.log(promoteTo);
 
-    gameSSBDao.getSituation(gameRootMessage).then(situation => {
-      if (situation.toMove !== myIdent) {
-        console.log("Not " + myIdent + " to move");
-      } else {
-
-        const pgnMoves = situation.pgnMoves;
-        chessWorker.postMessage({
-          'topic': 'move',
-          'payload': {
-            'fen': situation.fen,
-            'pgnMoves': pgnMoves,
-            'orig': originSquare,
-            'dest': destinationSquare,
-            'promotion': promoteTo
-          },
-          reqid: {
-            gameRootMessage: gameRootMessage,
-            originSquare: originSquare,
-            destinationSquare: destinationSquare,
-            players: situation.players
-          }
-
-        });
-
-      }
-    });
+    // gameSSBDao.getSituation(gameRootMessage).then(situation => {
+    //   if (situation.toMove !== myIdent) {
+    //     console.log("Not " + myIdent + " to move");
+    //   } else {
+    //
+    //     const pgnMoves = situation.pgnMoves;
+    //     chessWorker.postMessage({
+    //       'topic': 'move',
+    //       'payload': {
+    //         'fen': situation.fen,
+    //         'pgnMoves': pgnMoves,
+    //         'orig': originSquare,
+    //         'dest': destinationSquare,
+    //         'promotion': promoteTo
+    //       },
+    //       reqid: {
+    //         gameRootMessage: gameRootMessage,
+    //         originSquare: originSquare,
+    //         destinationSquare: destinationSquare,
+    //         players: situation.players
+    //       }
+    //
+    //     });
+    //
+    //   }
+    // });
   }
 
   function resignGame(gameId) {

--- a/ctrl/settings.js
+++ b/ctrl/settings.js
@@ -17,8 +17,6 @@ module.exports = () => {
   }
 
   function setMoveConfirmation(choice) {
-    console.log("setting move confirmation ");
-    console.log(choice);
       var chessSettings = getObject("ssb-chess");
       chessSettings.moveConfirmationEnabled = choice;
       storeSettings(chessSettings);

--- a/ctrl/settings.js
+++ b/ctrl/settings.js
@@ -1,0 +1,41 @@
+module.exports = () => {
+
+  function getObject(key) {
+    var item = localStorage.getItem(key);
+
+    if (item) {
+        return JSON.parse(item);
+    }
+    else {
+      return {};
+    }
+  }
+
+  function storeSettings(settings) {
+    var settingsAsString = JSON.stringify(settings);
+    localStorage.setItem('ssb-chess', settingsAsString);
+  }
+
+  function setMoveConfirmation(choice) {
+    console.log("setting move confirmation ");
+    console.log(choice);
+      var chessSettings = getObject("ssb-chess");
+      chessSettings.moveConfirmationEnabled = choice;
+      storeSettings(chessSettings);
+  }
+
+  function getMoveConfirmation() {
+    var chessSettings = getObject("ssb-chess");
+
+    if (chessSettings.moveConfirmationEnabled === undefined || chessSettings.moveConfirmationEnabled === null) {
+      return true;
+    } else {
+      return chessSettings.moveConfirmationEnabled;
+    }
+  }
+
+  return {
+    setMoveConfirmation: setMoveConfirmation,
+    getMoveConfirmation: getMoveConfirmation
+  }
+}

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ var PlayerProfileComponent = require('./ui/player/player_profile');
 var InvitationsComponent = require('./ui/invitations/invitations');
 var StatusBar = require('./ui/pageLayout/status_bar');
 
+var settingsCtrl = require('./ctrl/settings')();
+
 module.exports = (attachToElement, sbot, injectedApi) => {
 
   var cssFiles = [
@@ -39,7 +41,7 @@ module.exports = (attachToElement, sbot, injectedApi) => {
 
   function renderPageTop(parent, gameCtrl) {
 
-    var navBar = NavigationBar(gameCtrl);
+    var navBar = NavigationBar(gameCtrl, settingsCtrl);
     var statusBar = m(StatusBar());
 
     var TopComponent = {
@@ -56,7 +58,7 @@ module.exports = (attachToElement, sbot, injectedApi) => {
     m.route(mainBody, "/my_games", {
       "/my_games": MiniboardListComponent(gameCtrl, gameCtrl.getMyGamesInProgress, gameCtrl.getMyIdent()),
       "/games_my_move": MiniboardListComponent(gameCtrl, gameCtrl.getGamesWhereMyMove, gameCtrl.getMyIdent()),
-      "/games/:gameId": GameComponent(gameCtrl),
+      "/games/:gameId": GameComponent(gameCtrl, settingsCtrl),
       "/invitations": InvitationsComponent(gameCtrl),
       "/observable": MiniboardListComponent(gameCtrl, gameCtrl.getFriendsObservableGames, gameCtrl.getMyIdent()),
       "/player/:playerId": PlayerProfileComponent(gameCtrl)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-chess",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Multiplayer chess built on top of the secure-skuttlebutt platform.",
   "main": "inject.js",
   "dependencies": {

--- a/ui/game/gameActions.js
+++ b/ui/game/gameActions.js
@@ -1,9 +1,32 @@
 var m = require("mithril");
-var onceTrue = require('mutant/once-true')
+var onceTrue = require('mutant/once-true');
+var Value = require('mutant/value');
+var when = require('mutant/when');
+var computed = require('mutant/computed');
 
 module.exports = (gameMoveCtrl, myIdent, situationObservable) => {
 
   var observing = true;
+
+  var moveConfirmationObservable = makeMoveObservationListener();
+
+  function moveConfirmButtons() {
+
+    var confirmMove = () => {
+
+    }
+
+    var cancelMove = () => {
+      console.log("Cancelled move.");
+    }
+
+    return m('div', {class: 'ssb-chess-move-confirm-buttons'},
+      [
+        m('button', {onclick: confirmMove}, 'Confirm'),
+        m('button', {onclick: cancelMove}, 'Cancel')
+      ]
+    )
+  }
 
   function resignButton() {
     var resignGame = () => {
@@ -19,15 +42,57 @@ module.exports = (gameMoveCtrl, myIdent, situationObservable) => {
     return situation.players[myIdent] == null;
   }
 
+  function makeMoveObservationListener () {
+    var value = Value();
+
+    value.set({
+      moveNeedsConfirmed: false,
+      moveConfirmed: false
+    });
+
+    return value;
+  }
+
+  function moveNeedsConfirmed() {
+    // Eh, miby there's redundancy here, dunno :P
+
+    return computed(moveConfirmationObservable,
+       confirmation => confirmation.moveNeedsConfirmed);
+  }
+
+  function usualButtons() {
+    return resignButton();
+  }
+
   return {
     view: (vDom) => {
+
       return m('div', {
         class: "ssb-game-actions",
         style: observing ? "display: none;" : ""
-      }, [resignButton()]);
+      },
+        when(moveNeedsConfirmed(), moveConfirmButtons(), usualButtons())()
+      );
     },
     oncreate: function(vNode) {
       situationObservable(situation => observing = isObserving(situation));
+    },
+    showMoveConfirmation: function() {
+      moveConfirmationObservable.set({
+        moveNeedsConfirmed: true,
+        confirmed: false
+      });
+
+      return moveConfirmationObservable;
+    },
+    hideMoveConfirmation: function() {
+      moveConfirmationObservable.set({
+        moveNeedsConfirmed: false,
+        confirmed: false
+      });
+
+      return moveConfirmationObservable;
     }
+
   }
 }

--- a/ui/game/gameActions.js
+++ b/ui/game/gameActions.js
@@ -13,11 +13,19 @@ module.exports = (gameMoveCtrl, myIdent, situationObservable) => {
   function moveConfirmButtons() {
 
     var confirmMove = () => {
-
+      console.log("confirmed move");
+      moveConfirmationObservable.set({
+        moveNeedsConfirmed: false,
+        confirmed: true
+      })
     }
 
     var cancelMove = () => {
       console.log("Cancelled move.");
+      moveConfirmationObservable.set({
+        moveNeedsConfirmed: false,
+        confirmed: false
+      })
     }
 
     return m('div', {class: 'ssb-chess-move-confirm-buttons'},

--- a/ui/game/gameView.js
+++ b/ui/game/gameView.js
@@ -80,8 +80,10 @@ module.exports = (gameCtrl, settings) => {
         onConfirm();
       } else if (value.moveSelected !== "live" || value.moveConfirmed.confirmed === false) {
         var oldConfig = situationToChessgroundConfig(situation);
-        chessGround.set(oldConfig);
-        gameCtrl.getMoveCtrl().publishValidMoves(situation.gameId);
+
+        if (value.moveSelected === "live") {
+          chessGround.set(oldConfig)
+        }
       }
 
       removeConfirmationListener();

--- a/ui/game/gameView.js
+++ b/ui/game/gameView.js
@@ -74,6 +74,9 @@ module.exports = (gameCtrl) => {
         events: {
           after: (orig, dest, metadata) => {
 
+            var moveConfirmed = actionButtons.showMoveConfirmation();
+            m.redraw();
+
             if (isPromotionMove(chessGround, dest)) {
               var chessboardDom = document.getElementsByClassName("cg-board-wrap")[0];
 
@@ -83,7 +86,20 @@ module.exports = (gameCtrl) => {
                 }).renderPromotionOptionsOverlay();
 
             } else {
-              gameCtrl.getMoveCtrl().makeMove(situation.gameId, orig, dest);
+
+              var removeConfirmationListener = moveConfirmed(selected => {
+                if (selected.confirmed) {
+                  gameCtrl.getMoveCtrl().makeMove(situation.gameId, orig, dest);
+                } else {
+                  var oldConfig = situationToChessgroundConfig(situation);
+                  chessGround.set(oldConfig);
+                  gameCtrl.getMoveCtrl().publishValidMoves(situation.gameId);
+                }
+
+                removeConfirmationListener();
+                actionButtons.hideMoveConfirmation();
+              });
+
             }
 
             var notMovable = {

--- a/ui/game/gameView.js
+++ b/ui/game/gameView.js
@@ -114,7 +114,7 @@ module.exports = (gameCtrl) => {
                 gameCtrl.getMoveCtrl().makeMove(situation.gameId, orig, dest);
               }
 
-              watchForMoveConfirmation(situation, onConfirmMove);
+              watchForMoveConfirmation(situation, onConfirmMove)
             }
 
             var notMovable = {
@@ -246,6 +246,8 @@ module.exports = (gameCtrl) => {
       // Set the game history area to 'live mode' for the next game that is
       // opened
       gameHistory.goToLiveMode();
+
+      actionButtons.hideMoveConfirmation();
     }
   }
 

--- a/ui/pageLayout/navigation.js
+++ b/ui/pageLayout/navigation.js
@@ -51,23 +51,24 @@ module.exports = (gameCtrl, settings) => {
       ]));
   }
 
-  var showSettings = () => {
+  var closeSettingsDialog = () => {
     var dialogElementId = 'ssb-chess-settings-dialog';
-    var element = document.getElementById('ssb-chess-settings-dialog');
+    var element = document.getElementById(dialogElementId);
 
-    var closeDialog = () => {
-      var element = document.getElementById(dialogElementId);
-
-      if (element) {
-        element.parentNode.removeChild(element);
-      }
+    if (element) {
+      element.parentNode.removeChild(element);
     }
+  }
+
+  var showSettings = () => {
+
+    var element = document.getElementById('ssb-chess-settings-dialog');
 
     if (!element) {
       var container = document.createElement('div');
       container.id = 'ssb-chess-settings-dialog';
 
-      var settingsDialog = SettingsDialog(settings, closeDialog);
+      var settingsDialog = SettingsDialog(settings, closeSettingsDialog);
 
       document.body.appendChild(container);
       m.render(container, m(settingsDialog));

--- a/ui/pageLayout/navigation.js
+++ b/ui/pageLayout/navigation.js
@@ -1,7 +1,8 @@
 const m = require('mithril');
 const PubSub = require('pubsub-js');
+const SettingsDialog = require('../settings/settings-dialog');
 
-module.exports = (gameCtrl) => {
+module.exports = (gameCtrl, settings) => {
 
   const gamesInProgress = {
     name: "Games",
@@ -50,8 +51,35 @@ module.exports = (gameCtrl) => {
       ]));
   }
 
+  var showSettings = () => {
+    var dialogElementId = 'ssb-chess-settings-dialog';
+    var element = document.getElementById('ssb-chess-settings-dialog');
+
+    var closeDialog = () => {
+      var element = document.getElementById(dialogElementId);
+
+      if (element) {
+        element.parentNode.removeChild(element);
+      }
+    }
+
+    if (!element) {
+      var container = document.createElement('div');
+      container.id = 'ssb-chess-settings-dialog';
+
+      var settingsDialog = SettingsDialog(settings, closeDialog);
+
+      document.body.appendChild(container);
+      m.render(container, m(settingsDialog));
+    }
+
+  }
+
   function renderNavigation() {
-    return m('div', navItems.map(renderNavItem));
+    return m('div', [
+      navItems.map(renderNavItem),
+      m('a', {href: "#", onclick: showSettings}, 'SETTINGS')
+    ]);
   }
 
   function updateCounts() {

--- a/ui/pageLayout/navigation.js
+++ b/ui/pageLayout/navigation.js
@@ -78,7 +78,7 @@ module.exports = (gameCtrl, settings) => {
   function renderNavigation() {
     return m('div', [
       navItems.map(renderNavItem),
-      m('a', {href: "#", onclick: showSettings}, 'SETTINGS')
+      m('a', {id: 'ssb-chess-settings-nav-item', href: "#", onclick: showSettings}, 'SETTINGS')
     ]);
   }
 

--- a/ui/settings/settings-dialog.js
+++ b/ui/settings/settings-dialog.js
@@ -1,0 +1,40 @@
+const m = require('mithril');
+
+module.exports = (settingsCtrl, onCloseDialog) => {
+
+  function labelCheckbox(label, getSetting, onSelect) {
+    var checkboxSettings = {type: 'checkbox', 'class': 'ssb-chess-dialog-checkbox', checked: getSetting(),
+    onchange: (cb) => {
+      onSelect(cb.srcElement.checked)
+    }
+  };
+
+  if (getSetting() === true) {
+    checkboxSettings['checked'] = true;
+  }
+
+    return m('div', {
+      id: 'ssb-chess-dialog-checkbox-container'
+    }, [
+      m('span', {'class': 'ssb-chess-dialog-label'}, label),
+      m('input', checkboxSettings)
+    ])
+  }
+
+  function closeButton() {
+    return m('a', {href: '#', 'class': 'ssb-chess-settings-dialog-close', onclick: onCloseDialog}, 'Close');
+  }
+9
+  return {
+    view: () => {
+      return m('div', [
+        m('div', {class: 'ssb-chess-dialog-title'}, 'SETTINGS'),
+        labelCheckbox('Move confirmation',
+         settingsCtrl.getMoveConfirmation,
+          (selected) => settingsCtrl.setMoveConfirmation(selected)),
+        closeButton()
+      ])
+    }
+  }
+
+}

--- a/ui/settings/settings-dialog.js
+++ b/ui/settings/settings-dialog.js
@@ -22,7 +22,7 @@ module.exports = (settingsCtrl, onCloseDialog) => {
   }
 
   function closeButton() {
-    return m('a', {href: '#', 'id': 'ssb-chess-settings-dialog-close', onclick: onCloseDialog}, 'Close');
+    return m('button', {href: '#', 'id': 'ssb-chess-settings-dialog-close', onclick: onCloseDialog}, 'Close');
   }
 9
   return {

--- a/ui/settings/settings-dialog.js
+++ b/ui/settings/settings-dialog.js
@@ -24,7 +24,7 @@ module.exports = (settingsCtrl, onCloseDialog) => {
   function closeButton() {
     return m('button', {href: '#', 'id': 'ssb-chess-settings-dialog-close', onclick: onCloseDialog}, 'Close');
   }
-9
+
   return {
     view: () => {
       return m('div', [

--- a/ui/settings/settings-dialog.js
+++ b/ui/settings/settings-dialog.js
@@ -22,13 +22,13 @@ module.exports = (settingsCtrl, onCloseDialog) => {
   }
 
   function closeButton() {
-    return m('a', {href: '#', 'class': 'ssb-chess-settings-dialog-close', onclick: onCloseDialog}, 'Close');
+    return m('a', {href: '#', 'id': 'ssb-chess-settings-dialog-close', onclick: onCloseDialog}, 'Close');
   }
 9
   return {
     view: () => {
       return m('div', [
-        m('div', {class: 'ssb-chess-dialog-title'}, 'SETTINGS'),
+        m('div', {class: 'ssb-chess-dialog-title'}, ''),
         labelCheckbox('Move confirmation',
          settingsCtrl.getMoveConfirmation,
           (selected) => settingsCtrl.setMoveConfirmation(selected)),

--- a/ui/settings/settings-dialog.js
+++ b/ui/settings/settings-dialog.js
@@ -21,8 +21,24 @@ module.exports = (settingsCtrl, onCloseDialog) => {
     ])
   }
 
+  function closeDialog() {
+      document.removeEventListener('click', windowClickListener, true);
+      onCloseDialog();
+  }
+
+  function windowClickListener(event) {
+    var dialogElement = document.getElementById('ssb-chess-settings-dialog');
+    if (!dialogElement) {
+      return;
+    }
+
+    if((event.target != dialogElement) && !dialogElement.contains(event.target) ) {
+      closeDialog();
+    }
+  }
+
   function closeButton() {
-    return m('button', {href: '#', 'id': 'ssb-chess-settings-dialog-close', onclick: onCloseDialog}, 'Close');
+    return m('button', {href: '#', 'id': 'ssb-chess-settings-dialog-close', onclick: closeDialog}, 'Close');
   }
 
   return {
@@ -34,6 +50,9 @@ module.exports = (settingsCtrl, onCloseDialog) => {
           (selected) => settingsCtrl.setMoveConfirmation(selected)),
         closeButton()
       ])
+    },
+    oncreate: () => {
+      document.addEventListener('click', windowClickListener, true);
     }
   }
 


### PR DESCRIPTION
It is now possible to confirm / cancel a move after making it.

This behaviour can be disabled via the 'Settings' at the top right so that moves are made immediately without confirmation.

Closes #18