### PR TITLE
Don't use hardcoded ssb-chess-db version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "scuttlebot": "10.2.1",
     "ssb-backlinks": "^0.4.1",
     "ssb-embedded-chat": "1.1.0",
-    "ssb-chess-db": "^1.0.0",
     "ssb-links": "^2.0.0",
     "ssb-query": "1.0.0",
     "tiny-worker": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "scuttlebot": "10.2.1",
     "ssb-backlinks": "^0.4.1",
     "ssb-embedded-chat": "1.1.0",
-    "ssb-chess-db": "1.0.0",
+    "ssb-chess-db": "^1.0.0",
     "ssb-links": "^2.0.0",
     "ssb-query": "1.0.0",
     "tiny-worker": "2.1.1",


### PR DESCRIPTION
npm ls ssb-chess-db gives me 2 versions. 1.0.1 in main and 1.0.0 in ssb-chess. This should solve that.