### PR TITLE
first pass of routing to individual games

### DIFF
--- a/ctrl/game.js
+++ b/ctrl/game.js
@@ -15,7 +15,7 @@ const PlayerModelUtils = require('./player_model_utils')();
 const UserGamesUpdateWatcher = require('./user_game_updates_watcher');
 
 const Value = require('mutant/value');
-const Array = require('mutant/array');
+const MutantArray = require('mutant/array');
 const computed = require('mutant/computed');
 
 const _ = require('lodash');
@@ -88,7 +88,7 @@ module.exports = (sbot, myIdent, injectedApi) => {
   }
 
   function getGamesInProgress(playerId) {
-    var observable = Array([]);
+    var observable = MutantArray([]);
     gamesAgreedToPlaySummaries(playerId).then(g => observable.set(g.sort(compareGameTimestamps)));
 
     var playerGameUpdates = getGameUpdatesObservable(playerId);
@@ -109,7 +109,7 @@ module.exports = (sbot, myIdent, injectedApi) => {
   }
 
   function getFriendsObservableGames(start, end) {
-    var observable = Array([]);
+    var observable = MutantArray([]);
 
     var start = start ? start : 0;
     var end = end ? end : 20

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ var onceTrue = require('mutant/once-true');
 
 var Notifier = require('./ui/notify/notifier');
 
-module.exports = (attachToElement, sbot) => {
+module.exports = (attachToElement, sbot, opts = {}) => {
+  var { initialView } = opts
 
   var cssFiles = [
     "./css/global.css",
@@ -66,7 +67,9 @@ module.exports = (attachToElement, sbot) => {
     observableGamesObs(t => t);
     userRecentActivity(t => t);
 
-    m.route(mainBody, "/my_games", {
+    var defaultView = initialView || "/my_games"
+
+    m.route(mainBody, defaultView, {
       "/my_games": MiniboardListComponent(gameCtrl, gamesInProgressObs, gameCtrl.getMyIdent()),
       "/games_my_move": MiniboardListComponent(gameCtrl, gamesMyMoveObs , gameCtrl.getMyIdent()),
       "/games/:gameId": {

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ module.exports = (attachToElement, sbot, opts = {}) => {
   return {
     goToGame: (gameId) => {
       var gameRoute = `/games/${btoa(gameId)}`;
-    //  m.route.set(gameRoute);
+      m.route.set(gameRoute);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -118,4 +118,13 @@ module.exports = (attachToElement, sbot, opts = {}) => {
 
     appRouter(bodyDiv, gameCtrl);
   });
+
+  return {
+    goToGame: (gameId) => {
+      var gameRoute = `/games/${btoa(gameId)}`;
+    //  m.route.set(gameRoute);
+    }
+  }
+
+
 }

--- a/inject.js
+++ b/inject.js
@@ -8,6 +8,7 @@ const index = require('./index');
 
 exports.gives = nest({
   'app.html.menuItem': true,
+  'app.sync.locationId': true,
   'router.sync.routes': true,
 })
 
@@ -17,13 +18,13 @@ exports.needs = nest({
 });
 
 exports.create = function(api) {
-
   var pageLoaded = false;
-  var topLevelDomElement = null;
+  var topLevelDomElement = ChessContainer()
   var app = null;
 
   return nest({
     'app.html.menuItem': menuItem,
+    'app.sync.locationId': locationId,
     'router.sync.routes': routes,
   })
 
@@ -36,15 +37,11 @@ exports.create = function(api) {
     }, '/chess')
   }
 
-  function chessIndex(location) {
-
+  function chessIndex() {
     // We only create the app once (for now.)
     if (pageLoaded) {
-      topLevelDomElement.title = `/chess`;
-      topLevelDomElement.id = api.app.sync.locationId(location);
       return topLevelDomElement;
     } else {
-      topLevelDomElement = ChessContainer(location);
       pageLoaded = true;
 
       onceTrue(api.sbot.obs.connection, (sbot) => {
@@ -56,22 +53,19 @@ exports.create = function(api) {
   }
 
   function chessShow(location) {
-
     const gameId = location.key;
 
     // If the app is already open, route to the game, otherwise open the app at the
     // page
     if (pageLoaded) {
       app.goToGame(gameId);
+      // TODO - put this in the router?
       topLevelDomElement.title = `/chess/${getRoot(location)}`;
-      topLevelDomElement.id = api.app.sync.locationId(location);
 
       return topLevelDomElement;
     } else {
-
       var destinationRoute = `/games/${btoa(gameId)}`;
 
-      topLevelDomElement = ChessContainer(location);
       pageLoaded = true;
 
       onceTrue(api.sbot.obs.connection, (sbot) => {
@@ -95,16 +89,24 @@ exports.create = function(api) {
   }
 
 
-  function ChessContainer (location) {
+  function ChessContainer () {
     const root = h('div.ssb-chess-container')
-    root.title = location.page
-      ? '/chess'
-      : `/chess/${getRoot(location)}`
+    // root.title = location.page
+      // ? '/chess'
+      // : `/chess/${getRoot(location)}`
 
-    root.id = api.app.sync.locationId(location)
+    // root.id = api.app.sync.locationId(location)
+    
+    root.title = '/chess'
+    root.id = JSON.stringify({ page: 'chess' })
 
     return root
   }
+}
+
+function locationId (location) {
+  if (location.page === 'chess') return JSON.stringify({ page: 'chess' })
+  if (isChessMsg(location)) return JSON.stringify({ page: 'chess' })
 }
 
 function isChessMsg (loc) {

--- a/inject.js
+++ b/inject.js
@@ -40,6 +40,7 @@ exports.create = function(api) {
   function chessIndex() {
     // We only create the app once (for now.)
     if (pageLoaded) {
+      topLevelDomElement.title = '/chess';
       return topLevelDomElement;
     } else {
       pageLoaded = true;

--- a/inject.js
+++ b/inject.js
@@ -47,9 +47,10 @@ exports.create = function(api) {
 
   function chessShow(location) {
     const rootEl = ChessContainer(location);
+    const gameId = location.key;
 
     onceTrue(api.sbot.obs.connection, (sbot) => {
-      index(rootEl, sbot, { initialView: `/games/${btoa(location.game)}` });
+      index(rootEl, sbot, { initialView: `/games/${btoa(gameId)}` });
     });
 
     return rootEl
@@ -87,4 +88,3 @@ function isChessMsg (loc) {
 function getRoot (msg) {
   return get(msg, ['value', 'content', 'root'], msg.key)
 }
-


### PR DESCRIPTION
The behaviour I thought you wanted (could be wrong) is that if you click a link to message in patchbay which is associated with a chess game it opens a tab with that game in it.

This does that.
What's not working : 
- when you open a chess game, it opens 2 copies of the chat? (plus an additional one each time you open it subsequently?)
- when you open a chess game, if `/chess` is already open, the board might not display