### PR TITLE
Add linter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+css/chessground

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,12 @@
+module.exports = {
+  "extends": "eslint:recommended",
+  "env": {
+    "es6": true,
+    "browser": true,
+    "node": true
+  },
+  "rules": {
+    "no-console": "warn",
+    "no-unused-vars": "warn"
+  }
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,28 @@
 module.exports = {
-  "extends": "eslint:recommended",
+  "extends": "airbnb-base",
   "env": {
-    "es6": true,
     "browser": true,
     "node": true
   },
   "rules": {
     "no-console": "warn",
-    "no-unused-vars": "warn"
+    "no-unused-vars": "warn",
+    "prefer-destructuring": "warn",
+    "max-len": "warn",
+    "no-use-before-define": "warn",
+    "eqeqeq": "warn",
+    "no-prototype-builtins": "warn",
+    "consistent-return": "warn",
+    "import/order": "warn",
+    "no-param-reassign": "warn",
+    "no-shadow": "warn",
+    "guard-for-in": "warn",
+    "no-restricted-syntax": "warn",
+    "no-return-assign": "warn",
+    "no-plusplus": "warn",
+    "global-require": "warn",
+    "import/no-extraneous-dependencies": [
+      "error", { devDependencies: true }
+    ]
   }
-}
+};

--- a/css/chessground/gulpfile.js
+++ b/css/chessground/gulpfile.js
@@ -10,7 +10,7 @@ const destination = './dist';
 
 function onError(error) {
   return gutil.log(gutil.colors.red(error.message));
-};
+}
 
 function build(debug) {
   return browserify('src/main.ts', {

--- a/ctrl/game.js
+++ b/ctrl/game.js
@@ -113,11 +113,11 @@ module.exports = (sbot, myIdent, injectedApi) => {
     );
   }
 
-  function getFriendsObservableGames(start, end) {
-    var observable = MutantArray([]);
+  function getFriendsObservableGames(startArg, endArg) {
+    const observable = MutantArray([]);
 
-    var start = start ? start : 0;
-    var end = end ? end : 20
+    const start = startArg || 0;
+    const end = endArg || 20
 
     gameDb.getObservableGames(myIdent, start, end).then(
       gameIds => Promise.all(

--- a/ctrl/game_move.js
+++ b/ctrl/game_move.js
@@ -1,34 +1,30 @@
-const PlayerModelUtils = require("./player_model_utils")();
+const PlayerModelUtils = require('./player_model_utils')();
 
 module.exports = (gameSSBDao, myIdent, chessWorker) => {
-
   function makeMove(gameRootMessage, originSquare, destinationSquare, promoteTo) {
-
-    gameSSBDao.getSituation(gameRootMessage).then(situation => {
+    gameSSBDao.getSituation(gameRootMessage).then((situation) => {
       if (situation.toMove !== myIdent) {
-        console.log("Not " + myIdent + " to move");
+        console.log(`Not ${myIdent} to move`);
       } else {
-
         const pgnMoves = situation.pgnMoves;
         chessWorker.postMessage({
-          'topic': 'move',
-          'payload': {
-            'fen': situation.fen,
-            'pgnMoves': pgnMoves,
-            'orig': originSquare,
-            'dest': destinationSquare,
-            'promotion': promoteTo
+          topic: 'move',
+          payload: {
+            fen: situation.fen,
+            pgnMoves,
+            orig: originSquare,
+            dest: destinationSquare,
+            promotion: promoteTo,
           },
           reqid: {
-            gameRootMessage: gameRootMessage,
-            originSquare: originSquare,
-            destinationSquare: destinationSquare,
+            gameRootMessage,
+            originSquare,
+            destinationSquare,
             players: situation.players,
-            respondsTo: situation.latestUpdateMsg
-          }
+            respondsTo: situation.latestUpdateMsg,
+          },
 
         });
-
       }
     });
   }
@@ -43,26 +39,25 @@ module.exports = (gameSSBDao, myIdent, chessWorker) => {
     const gameRootMessage = e.data.reqid.gameRootMessage;
     const originSquare = e.data.reqid.originSquare;
     const destinationSquare = e.data.reqid.destinationSquare;
-    let respondsTo
+    let respondsTo;
 
     if (e.data.payload.error) {
-      console.log("move error");
+      console.log('move error');
       console.dir(e);
-      PubSub.publish("move_error", e.data.payload.error);
+      PubSub.publish('move_error', e.data.payload.error);
     } else if (e.data.topic === 'move' && e.data.payload.situation.end) {
-
-      var status = e.data.payload.situation.status;
-      var winner = e.data.payload.situation.winner;
-      var ply = e.data.payload.situation.ply;
-      var fen = e.data.payload.situation.fen;
-      var players = e.data.reqid.players;
+      const status = e.data.payload.situation.status;
+      const winner = e.data.payload.situation.winner;
+      const ply = e.data.payload.situation.ply;
+      const fen = e.data.payload.situation.fen;
+      const players = e.data.reqid.players;
       respondsTo = e.data.reqid.respondsTo;
 
-      var pgnMove = ply > 0 ? e.data.payload.situation.pgnMoves[e.data.payload.situation.pgnMoves.length - 1] : null;
+      const pgnMove = ply > 0 ? e.data.payload.situation.pgnMoves[e.data.payload.situation.pgnMoves.length - 1] : null;
 
-      var coloursToPlayer = PlayerModelUtils.coloursToPlayer(players);
+      const coloursToPlayer = PlayerModelUtils.coloursToPlayer(players);
 
-      var winnerId = winner ? coloursToPlayer[winner].id : null;
+      const winnerId = winner ? coloursToPlayer[winner].id : null;
 
       gameSSBDao.endGame(
         gameRootMessage,
@@ -73,9 +68,9 @@ module.exports = (gameSSBDao, myIdent, chessWorker) => {
         originSquare,
         destinationSquare,
         pgnMove,
-        respondsTo);
+        respondsTo,
+      );
     } else if (e.data.topic === 'move') {
-
       respondsTo = e.data.reqid.respondsTo;
 
       gameSSBDao.makeMove(
@@ -86,7 +81,7 @@ module.exports = (gameSSBDao, myIdent, chessWorker) => {
         e.data.payload.situation.promotion,
         e.data.payload.situation.pgnMoves[e.data.payload.situation.pgnMoves.length - 1],
         e.data.payload.situation.fen,
-        respondsTo
+        respondsTo,
       );
     }
   }
@@ -94,7 +89,7 @@ module.exports = (gameSSBDao, myIdent, chessWorker) => {
   chessWorker.addEventListener('message', handleChessWorkerResponse);
 
   return {
-    makeMove: makeMove,
-    resignGame: resignGame
-  }
-}
+    makeMove,
+    resignGame,
+  };
+};

--- a/ctrl/game_move.js
+++ b/ctrl/game_move.js
@@ -43,6 +43,7 @@ module.exports = (gameSSBDao, myIdent, chessWorker) => {
     const gameRootMessage = e.data.reqid.gameRootMessage;
     const originSquare = e.data.reqid.originSquare;
     const destinationSquare = e.data.reqid.destinationSquare;
+    let respondsTo
 
     if (e.data.payload.error) {
       console.log("move error");
@@ -55,7 +56,7 @@ module.exports = (gameSSBDao, myIdent, chessWorker) => {
       var ply = e.data.payload.situation.ply;
       var fen = e.data.payload.situation.fen;
       var players = e.data.reqid.players;
-      var respondsTo = e.data.reqid.respondsTo;
+      respondsTo = e.data.reqid.respondsTo;
 
       var pgnMove = ply > 0 ? e.data.payload.situation.pgnMoves[e.data.payload.situation.pgnMoves.length - 1] : null;
 
@@ -75,7 +76,7 @@ module.exports = (gameSSBDao, myIdent, chessWorker) => {
         respondsTo);
     } else if (e.data.topic === 'move') {
 
-      var respondsTo = e.data.reqid.respondsTo;
+      respondsTo = e.data.reqid.respondsTo;
 
       gameSSBDao.makeMove(
         gameRootMessage,

--- a/ctrl/pgn.js
+++ b/ctrl/pgn.js
@@ -1,63 +1,57 @@
-const Promise = require("bluebird");
-const Worker = require("tiny-worker");
+const Promise = require('bluebird');
+const Worker = require('tiny-worker');
 
 module.exports = (gameSSBDao, chessWorker) => {
-
   function postWorkerMessage(chessWorker, situation) {
     chessWorker.postMessage({
       topic: 'pgnDump',
       payload: {
-        'initialFen': situation.getInitialFen(),
-        'pgnMoves': situation.pgnMoves,
-        'white': `${situation.getWhitePlayer().name} (${situation.getWhitePlayer().id})`,
-        'black': `${situation.getBlackPlayer().name} (${situation.getBlackPlayer().id})`,
-        'date': new Date(situation.lastUpdateTime).toString()
+        initialFen: situation.getInitialFen(),
+        pgnMoves: situation.pgnMoves,
+        white: `${situation.getWhitePlayer().name} (${situation.getWhitePlayer().id})`,
+        black: `${situation.getBlackPlayer().name} (${situation.getBlackPlayer().id})`,
+        date: new Date(situation.lastUpdateTime).toString(),
       },
       reqid: {
-        gameRootMessage: situation.gameId
-      }
-    })
+        gameRootMessage: situation.gameId,
+      },
+    });
   }
 
   function addChessSite(pgn) {
     // TODO : make pull request on scalachessjs to paramaterise this.
-    return pgn.replace(`[Site "https://lichess.org"]`, `[Site "ssb-chess (https://github.com/happy0/ssb-chess)"]`  )
+    return pgn.replace('[Site "https://lichess.org"]', '[Site "ssb-chess (https://github.com/happy0/ssb-chess)"]');
   }
 
   function handlePgnResponse(event, gameId, resolve, reject) {
-    if (event.data.topic === "pgnDump" && event.data.reqid.gameRootMessage === gameId ) {
-      var pgnText = addChessSite(event.data.payload.pgn);
+    if (event.data.topic === 'pgnDump' && event.data.reqid.gameRootMessage === gameId) {
+      const pgnText = addChessSite(event.data.payload.pgn);
       resolve(pgnText);
-    } else if (event.error === "error") {
+    } else if (event.error === 'error') {
       reject(event.error);
     }
   }
 
   function awaitPgnResponse(chessWorker, gameId) {
+    let handler = null;
 
-    var handler = null;
-
-    return new Promise( (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       // Yuck, need to remove event listener using same function reference
-      handler = (event) => handlePgnResponse(event, gameId, resolve, reject);
+      handler = event => handlePgnResponse(event, gameId, resolve, reject);
       chessWorker.addEventListener('message', handler);
-    }).finally( () => chessWorker.terminate() );
+    }).finally(() => chessWorker.terminate());
   }
 
   return {
-    getPgnExport: (gameId) => {
-      return new Promise ( (resolve, reject) => {
+    getPgnExport: gameId => new Promise((resolve, reject) => {
+      const rootDir = `${__dirname.replace('ctrl', '')}/`;
+      const chessWorker = new Worker(`${rootDir}vendor/scalachessjs/scalachess.js`);
 
-        var rootDir = __dirname.replace("ctrl","") + "/";
-        const chessWorker = new Worker(rootDir + 'vendor/scalachessjs/scalachess.js');
+      // Yuck. Make sure the event listener is set up before posting the web worker message.
+      // Well, at least the caller gets a nice promise back to hook on to =p.
+      awaitPgnResponse(chessWorker, gameId).then(resolve).catch(reject);
 
-        // Yuck. Make sure the event listener is set up before posting the web worker message.
-        // Well, at least the caller gets a nice promise back to hook on to =p.
-        awaitPgnResponse(chessWorker, gameId).then(resolve).catch(reject);
-
-        gameSSBDao.getSituation(gameId).then((situation) => postWorkerMessage(chessWorker, situation)).catch(reject);
-      });
-    }
-  }
-
-}
+      gameSSBDao.getSituation(gameId).then(situation => postWorkerMessage(chessWorker, situation)).catch(reject);
+    }),
+  };
+};

--- a/ctrl/player.js
+++ b/ctrl/player.js
@@ -1,7 +1,6 @@
-var pull = require("pull-stream");
+const pull = require('pull-stream');
 
 module.exports = (sbot, gameDb, gameSsbCtrl) => {
-
   function endedGamesPagesSource(playerId) {
     return gameDb.getGamesFinished(playerId);
   }
@@ -13,16 +12,15 @@ module.exports = (sbot, gameDb, gameSsbCtrl) => {
   }
 
   function endedGamesSummariesSource(playerId) {
-    var endedGamesSrc = endedGamesPagesSource(playerId);
+    const endedGamesSrc = endedGamesPagesSource(playerId);
 
-    var flatStream = pull(endedGamesSrc, pull.flatten());
+    const flatStream = pull(endedGamesSrc, pull.flatten());
 
     return pull(flatStream, pull.asyncMap(getGameSummaryCb));
   }
 
 
   return {
-    endedGamesSummariesSource: endedGamesSummariesSource
-  }
-
-}
+    endedGamesSummariesSource,
+  };
+};

--- a/ctrl/player_model_utils.js
+++ b/ctrl/player_model_utils.js
@@ -1,23 +1,22 @@
 module.exports = () => {
-
   function coloursToNames(json) {
-    var ret = {};
-    for (var key in json) {
+    const ret = {};
+    for (const key in json) {
       ret[json[key].colour] = json[key].name;
     }
     return ret;
   }
 
   function coloursToPlayer(json) {
-    var ret = {};
-    for (var key in json) {
+    const ret = {};
+    for (const key in json) {
       ret[json[key].colour] = json[key];
     }
     return ret;
   }
 
   return {
-    coloursToNames: coloursToNames,
-    coloursToPlayer: coloursToPlayer
-  }
-}
+    coloursToNames,
+    coloursToPlayer,
+  };
+};

--- a/ctrl/settings.js
+++ b/ctrl/settings.js
@@ -1,57 +1,53 @@
 module.exports = () => {
-
   function getObject(key) {
-    var item = localStorage.getItem(key);
+    const item = localStorage.getItem(key);
 
     if (item) {
-        return JSON.parse(item);
+      return JSON.parse(item);
     }
-    else {
-      return {};
-    }
+
+    return {};
   }
 
   function storeSettings(settings) {
-    var settingsAsString = JSON.stringify(settings);
+    const settingsAsString = JSON.stringify(settings);
     localStorage.setItem('ssb-chess', settingsAsString);
   }
 
   function setMoveConfirmation(choice) {
-      var chessSettings = getObject("ssb-chess");
-      chessSettings.moveConfirmationEnabled = choice;
-      storeSettings(chessSettings);
+    const chessSettings = getObject('ssb-chess');
+    chessSettings.moveConfirmationEnabled = choice;
+    storeSettings(chessSettings);
   }
 
   function getMoveConfirmation() {
-    var chessSettings = getObject("ssb-chess");
+    const chessSettings = getObject('ssb-chess');
 
     if (chessSettings.moveConfirmationEnabled === undefined || chessSettings.moveConfirmationEnabled === null) {
       return true;
-    } else {
-      return chessSettings.moveConfirmationEnabled;
     }
+    return chessSettings.moveConfirmationEnabled;
   }
 
   function setPlaySounds(choice) {
-    var chessSettings = getObject("ssb-chess");
+    const chessSettings = getObject('ssb-chess');
     chessSettings.playSounds = choice;
     storeSettings(chessSettings);
   }
 
   function getPlaySounds() {
-    var chessSettings = getObject("ssb-chess");
+    const chessSettings = getObject('ssb-chess');
 
     if (chessSettings.playSounds === undefined || chessSettings.playSounds === null) {
       return true;
-    } else {
-      return chessSettings.playSounds;
     }
+    return chessSettings.playSounds;
   }
 
   return {
-    setMoveConfirmation: setMoveConfirmation,
-    getMoveConfirmation: getMoveConfirmation,
-    getPlaySounds: getPlaySounds,
-    setPlaySounds: setPlaySounds
-  }
-}
+    setMoveConfirmation,
+    getMoveConfirmation,
+    getPlaySounds,
+    setPlaySounds,
+  };
+};

--- a/ctrl/social.js
+++ b/ctrl/social.js
@@ -1,7 +1,6 @@
-var SocialCtrl = require("../ssb_ctrl/social");
+const SocialCtrl = require('../ssb_ctrl/social');
 
 module.exports = (sbot, myIdent) => {
-
   const socialCtrl = SocialCtrl(sbot, myIdent);
 
   function followingMe() {
@@ -14,39 +13,35 @@ module.exports = (sbot, myIdent) => {
 
   function identWithDisplayName(ident) {
     return socialCtrl.getPlayerDisplayName(ident).then(name => ({
-      'ident': ident,
-      'displayName': name
+      ident,
+      displayName: name,
     }));
   }
 
   function friends() {
-    var iFollow = followedByMe();
-    var followsMe = followingMe();
+    const iFollow = followedByMe();
+    const followsMe = followingMe();
 
-    return Promise.all([iFollow, followsMe]).then(results => {
-      var following = results[0];
-      var followedBy = results[1];
+    return Promise.all([iFollow, followsMe]).then((results) => {
+      const following = results[0];
+      const followedBy = results[1];
 
-      return following.filter(function(n) {
-        return followedBy.indexOf(n) !== -1;
-      });
-    })
-
+      return following.filter(n => followedBy.indexOf(n) !== -1);
+    });
   }
 
   function friendsWithNames() {
-    return friends().then(palaroonis => {
-      var namesWithIdents = palaroonis.map(identWithDisplayName);
+    return friends().then((palaroonis) => {
+      const namesWithIdents = palaroonis.map(identWithDisplayName);
 
-      return Promise.all(namesWithIdents)
+      return Promise.all(namesWithIdents);
     });
   }
 
   return {
-    followingMe: followingMe,
-    followedByMe: followedByMe,
-    friends: friends,
-    friendsWithNames: friendsWithNames
-  }
-
-}
+    followingMe,
+    followedByMe,
+    friends,
+    friendsWithNames,
+  };
+};

--- a/ctrl/userViewingGame.js
+++ b/ctrl/userViewingGame.js
@@ -1,14 +1,13 @@
-var PubSub = require('pubsub-js');
+const PubSub = require('pubsub-js');
 
 module.exports = () => {
+  let currentGameId = null;
 
-  var currentGameId = null;
-
-  function lookingAtGame (gameId) {
+  function lookingAtGame(gameId) {
     currentGameId = gameId;
   }
 
-  function notLookingAtGame () {
+  function notLookingAtGame() {
     currentGameId = null;
   }
 
@@ -18,9 +17,9 @@ module.exports = () => {
 
   PubSub.subscribe('exited_game', () => {
     notLookingAtGame();
-  })
+  });
 
   return {
-    getCurrentGame: () => currentGameId
-  }
-}
+    getCurrentGame: () => currentGameId,
+  };
+};

--- a/ctrl/user_game_updates_watcher.js
+++ b/ctrl/user_game_updates_watcher.js
@@ -1,121 +1,109 @@
-var asyncRemove = require('pull-async-filter');
-var concatStreams = require('pull-cat');
-var computed = require('mutant/computed');
-var pull = require('pull-stream');
-var many = require('pull-many')
-var MutantArray = require('mutant/array');
-var MutantPullReduce = require('mutant-pull-reduce');
+const asyncRemove = require('pull-async-filter');
+const concatStreams = require('pull-cat');
+const computed = require('mutant/computed');
+const pull = require('pull-stream');
+const many = require('pull-many');
+const MutantArray = require('mutant/array');
+const MutantPullReduce = require('mutant-pull-reduce');
 
 module.exports = (sbot) => {
-
   const chessTypeMessages = [
-   "chess_invite",
-   "chess_move",
-   "chess_invite_accept",
-   "chess_game_end"];
+    'chess_invite',
+    'chess_move',
+    'chess_invite_accept',
+    'chess_game_end'];
 
   function latestGameMessageForPlayerObs(playerId) {
-
-    var opts = {
+    const opts = {
       since: Date.now(),
-      reverse: false
-    }
+      reverse: false,
+    };
 
-    var chessMessagesReferencingPlayer = chessMessagesForPlayerGames(playerId, opts);
+    const chessMessagesReferencingPlayer = chessMessagesForPlayerGames(playerId, opts);
 
-    return MutantPullReduce(chessMessagesReferencingPlayer, (state, next) => {
-      return next;
-    }, {
+    return MutantPullReduce(chessMessagesReferencingPlayer, (state, next) => next, {
       nextTick: true,
-      sync: true
+      sync: true,
     });
   }
 
   function latestGameMessageForOtherPlayersObs(playerId) {
-
-    var opts = {
+    const opts = {
       since: Date.now(),
-      reverse: false
-    }
+      reverse: false,
+    };
 
-    var observingGamesMsgs = chessMessagesForOtherPlayersGames(playerId, opts);
+    const observingGamesMsgs = chessMessagesForOtherPlayersGames(playerId, opts);
 
-    return MutantPullReduce(observingGamesMsgs, (state, next) => {
-      return next;
-    }, {
+    return MutantPullReduce(observingGamesMsgs, (state, next) => next, {
       nextTick: true,
-      sync: true
+      sync: true,
     });
   }
 
   function chessMessagesForPlayerGames(playerId, opts) {
-    var since = opts ? opts.since : null;
-    var reverse = opts ? opts.reverse : false;
-    var messageTypes = opts && opts.messageTypes ? opts.messageTypes : chessTypeMessages;
+    const since = opts ? opts.since : null;
+    const reverse = opts ? opts.reverse : false;
+    const messageTypes = opts && opts.messageTypes ? opts.messageTypes : chessTypeMessages;
 
     // Default to live
-    var liveStream = (opts && (opts.live !== undefined && opts.live !== null )) ? opts.live : true
+    const liveStream = (opts && (opts.live !== undefined && opts.live !== null)) ? opts.live : true;
 
-    var liveFeed = sbot.createLogStream({
+    const liveFeed = sbot.createLogStream({
       live: liveStream,
       gt: since,
-      reverse: reverse
-    })
+      reverse,
+    });
 
     return pull(
       liveFeed,
       msgMatchesFilter(
         playerId,
         true,
-        messageTypes
-      )
-     )
+        messageTypes,
+      ),
+    );
   }
 
   function chessMessagesForOtherPlayersGames(playerId, opts) {
-    var since = opts ? opts.since : null;
-    var reverse = opts ? opts.reverse : false;
-    var messageTypes = opts && opts.messageTypes ? opts.messageTypes : chessTypeMessages;
+    const since = opts ? opts.since : null;
+    const reverse = opts ? opts.reverse : false;
+    const messageTypes = opts && opts.messageTypes ? opts.messageTypes : chessTypeMessages;
 
-    var liveFeed = sbot.createLogStream({
+    const liveFeed = sbot.createLogStream({
       live: true,
       gt: since,
-      reverse: reverse
-    })
+      reverse,
+    });
 
     return pull(
       liveFeed,
       msgMatchesFilter(
         playerId,
         false,
-        messageTypes
-      )
-     )
+        messageTypes,
+      ),
+    );
   }
 
   function getGameId(msg) {
-
-    if (msg.value.content.type === "chess_invite") {
+    if (msg.value.content.type === 'chess_invite') {
       return msg.key;
     }
-    else if (!msg.value || !msg.value.content || !msg.value.content.root) {
-      console.warn("No root found for chess message ");
+    if (!msg.value || !msg.value.content || !msg.value.content.root) {
+      console.warn('No root found for chess message ');
       console.warn(msg);
       return null;
-    } else {
-      return msg.value.content.root;
     }
+    return msg.value.content.root;
   }
 
   function isChessMessage(msg, msgTypes) {
-
     if (!msg.value || !msg.value.content) {
       return false;
     }
-    else {
-      return msgTypes.indexOf(msg.value.content.type) !== -1
-    }
 
+    return msgTypes.indexOf(msg.value.content.type) !== -1;
   }
 
   function containsPlayerId(playerId, players) {
@@ -124,69 +112,64 @@ module.exports = (sbot) => {
 
   function msgMatchesFilter(playerId, playerShouldBeInGame, messageTypes) {
     return pull(
-              pull(
-                pull.filter(msg => isChessMessage(msg, messageTypes)),
-                asyncRemove((msg, cb) => {
-                var gameId = getGameId(msg);
+      pull(
+        pull.filter(msg => isChessMessage(msg, messageTypes)),
+        asyncRemove((msg, cb) => {
+          const gameId = getGameId(msg);
 
-                if (gameId == null) {
-                  cb(null, false);
-                } else {
-                  sbot.ssbChessIndex.gameHasPlayer(gameId, playerId, (err, result) => {
-                    if (playerShouldBeInGame) {
-                      cb(err, !result);
-                    } else {
-                      cb(err, result);
-                    }
-
-                  })
-                }
-              })
-            )
-          )
+          if (gameId == null) {
+            cb(null, false);
+          } else {
+            sbot.ssbChessIndex.gameHasPlayer(gameId, playerId, (err, result) => {
+              if (playerShouldBeInGame) {
+                cb(err, !result);
+              } else {
+                cb(err, result);
+              }
+            });
+          }
+        }),
+      ),
+    );
   }
 
   function getRingBufferGameMsgsForPlayer(id, getSituationObservable, msgTypes, size, opts) {
-    var since = opts ? opts.since : null;
+    const since = opts ? opts.since : null;
 
-    var nonLiveMsgSources = msgTypes.map(type =>
-       pull(
-         sbot.messagesByType({type : type, reverse: true, gte: since}),
-         msgMatchesFilter(id, true, msgTypes)
-       )
-     );
+    const nonLiveMsgSources = msgTypes.map(type => pull(
+      sbot.messagesByType({ type, reverse: true, gte: since }),
+      msgMatchesFilter(id, true, msgTypes),
+    ));
 
-    var liveStream = chessMessagesForPlayerGames(id, {
+    const liveStream = chessMessagesForPlayerGames(id, {
       live: true,
       // Go Back a minute in case we missed any while loading the old ones.
       since: Date.now() - 60000,
-      messageTypes: msgTypes
+      messageTypes: msgTypes,
     });
 
-    var oldEntries = pull(
+    const oldEntries = pull(
       pull(
-        many(nonLiveMsgSources)),
-        pull.take(size)
-      );
+        many(nonLiveMsgSources),
+      ),
+      pull.take(size),
+    );
 
     // Take a limited amount of old messages and then add any new live messages to
     // the top of the observable list
-    var stream = concatStreams([oldEntries, liveStream]);
+    const stream = concatStreams([oldEntries, liveStream]);
 
-    var obsArray = MutantArray([]);
+    const obsArray = MutantArray([]);
 
-    var count = 0;
-    var pushToFront = false;
+    let count = 0;
+    let pushToFront = false;
     pull(stream, pull.drain((msg) => {
+      const situationObs = getSituationObservable(msg.value.content.root);
 
-      var situationObs = getSituationObservable(msg.value.content.root);
-
-      var entry = computed([situationObs], situation => {
-        return {
-          msg: msg,
-          situation: situation
-        }
-      })
+      const entry = computed([situationObs], situation => ({
+        msg,
+        situation,
+      }));
 
       if (msg.sync) {
         // When we have reached messages arriving live in the stream, we start
@@ -200,50 +183,48 @@ module.exports = (sbot) => {
           // Remove the oldest entry if we have reached capacity.
           obsArray.pop();
         }
-
       } else {
-        obsArray.push(entry)
+        obsArray.push(entry);
       }
 
       count++;
-    }))
+    }));
 
     // Sort in descending order
-    return computed([obsArray], array =>
-       array.sort( (a,b) => b.msg.timestamp - a.msg.timestamp) );
+    return computed([obsArray], array => array.sort((a, b) => b.msg.timestamp - a.msg.timestamp));
   }
 
   return {
-   /**
+    /**
     * Watches for incoming updates to a player's games and sets the observable
     * value to the latest chess message.
     */
-   latestGameMessageForPlayerObs : latestGameMessageForPlayerObs,
+    latestGameMessageForPlayerObs,
 
-   /**
+    /**
     * Watches for incoming updates to a games a player is not playing in and
     * sets the observable value to the latest chess message.
     */
-   latestGameMessageForOtherPlayersObs: latestGameMessageForOtherPlayersObs,
+    latestGameMessageForOtherPlayersObs,
 
-   /**
+    /**
     * Get a ring buffer of game messages of a given type concerning a player's game.
     * @playerId the id of the player to track game messages for.
     * @msgs an array of game type messages to fill the buffer with, and a size for the
     * @size The size of the ring buffer.
     */
-   getRingBufferGameMsgsForPlayer: getRingBufferGameMsgsForPlayer,
+    getRingBufferGameMsgsForPlayer,
 
-   /**
+    /**
    * A stream of chess game messages (excluding chat messages) for the given
    * user after the given timestamp.
    */
-   chessMessagesForPlayerGames: chessMessagesForPlayerGames,
+    chessMessagesForPlayerGames,
 
-   /**
+    /**
     * A stream of chess game messages for games that the player of the
     * given ID is not playing in.
     */
-   chessMessagesForOtherPlayersGames: chessMessagesForOtherPlayersGames
-  }
-}
+    chessMessagesForOtherPlayersGames,
+  };
+};

--- a/db/game_db.js
+++ b/db/game_db.js
@@ -1,53 +1,52 @@
-var pull = require("pull-stream");
+const pull = require('pull-stream');
 
 module.exports = (sbot) => {
-
   function pendingChallengesSent(playerId) {
-    return new Promise( (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       sbot.ssbChessIndex.pendingChallengesSent(playerId, (err, result) => {
         if (err) {
           reject(err);
         } else {
           resolve(result);
         }
-      })
-    })
+      });
+    });
   }
 
   function pendingChallengesReceived(playerId) {
-    return new Promise( (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       sbot.ssbChessIndex.pendingChallengesReceived(playerId, (err, result) => {
         if (err) {
           reject(err);
         } else {
           resolve(result);
         }
-      })
-    })
+      });
+    });
   }
 
   function getGamesAgreedToPlayIds(playerId) {
-    return new Promise( (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       sbot.ssbChessIndex.getGamesAgreedToPlayIds(playerId, (err, result) => {
         if (err) {
           reject(err);
         } else {
           resolve(result);
         }
-      })
-    })
+      });
+    });
   }
 
   function getObservableGames(playerId) {
-    return new Promise( (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       sbot.ssbChessIndex.getObservableGames(playerId, (err, result) => {
         if (err) {
           reject(err);
         } else {
           resolve(result);
         }
-      })
-    })
+      });
+    });
   }
 
   function getGamesFinished(playerId) {
@@ -55,10 +54,10 @@ module.exports = (sbot) => {
   }
 
   return {
-    pendingChallengesSent: pendingChallengesSent,
-    pendingChallengesReceived: pendingChallengesReceived,
-    getGamesAgreedToPlayIds: getGamesAgreedToPlayIds,
-    getObservableGames: getObservableGames,
-    getGamesFinished: getGamesFinished
-  }
-}
+    pendingChallengesSent,
+    pendingChallengesReceived,
+    getGamesAgreedToPlayIds,
+    getObservableGames,
+    getGamesFinished,
+  };
+};

--- a/inject.js
+++ b/inject.js
@@ -10,31 +10,31 @@ exports.gives = nest({
   'app.html.menuItem': true,
   'app.sync.locationId': true,
   'router.sync.routes': true,
-})
+});
 
 exports.needs = nest({
   'app.sync.locationId': 'first',
-  'sbot.obs.connection': 'first'
+  'sbot.obs.connection': 'first',
 });
 
-exports.create = function(api) {
-  var pageLoaded = false;
-  var topLevelDomElement = ChessContainer()
-  var app = null;
+exports.create = function (api) {
+  let pageLoaded = false;
+  const topLevelDomElement = ChessContainer();
+  let app = null;
 
   return nest({
     'app.html.menuItem': menuItem,
     'app.sync.locationId': locationId,
     'router.sync.routes': routes,
-  })
+  });
 
   function menuItem(handleClick) {
     return h('a', {
       style: {
-        order: 0
+        order: 0,
       },
-      'ev-click': () => handleClick({ page: 'chess' })
-    }, '/chess')
+      'ev-click': () => handleClick({ page: 'chess' }),
+    }, '/chess');
   }
 
   function chessIndex() {
@@ -42,15 +42,14 @@ exports.create = function(api) {
     if (pageLoaded) {
       topLevelDomElement.title = '/chess';
       return topLevelDomElement;
-    } else {
-      pageLoaded = true;
-
-      onceTrue(api.sbot.obs.connection, (sbot) => {
-        app = index(topLevelDomElement, sbot);
-      });
-
-      return topLevelDomElement
     }
+    pageLoaded = true;
+
+    onceTrue(api.sbot.obs.connection, (sbot) => {
+      app = index(topLevelDomElement, sbot);
+    });
+
+    return topLevelDomElement;
   }
 
   function chessShow(location) {
@@ -64,57 +63,55 @@ exports.create = function(api) {
       topLevelDomElement.title = `/chess/${getRoot(location)}`;
 
       return topLevelDomElement;
-    } else {
-      var destinationRoute = `/games/${btoa(gameId)}`;
-
-      pageLoaded = true;
-
-      onceTrue(api.sbot.obs.connection, (sbot) => {
-        app = index(topLevelDomElement, sbot, { initialView: destinationRoute });
-      });
-
-      return topLevelDomElement;
     }
+    const destinationRoute = `/games/${btoa(gameId)}`;
 
+    pageLoaded = true;
+
+    onceTrue(api.sbot.obs.connection, (sbot) => {
+      app = index(topLevelDomElement, sbot, { initialView: destinationRoute });
+    });
+
+    return topLevelDomElement;
   }
 
-  function routes (sofar = []) {
+  function routes(sofar = []) {
     // loc = location, an object with all the info required to specify a location
     const routes = [
-      [ loc => loc.page === 'chess', chessIndex ],
-      [ loc => isChessMsg(loc), chessShow],
-    ]
+      [loc => loc.page === 'chess', chessIndex],
+      [loc => isChessMsg(loc), chessShow],
+    ];
 
     // this stacks chess routes below routes loaded by depject so far (polite)
-    return [...sofar, ...routes]
+    return [...sofar, ...routes];
   }
 
 
-  function ChessContainer () {
-    const root = h('div.ssb-chess-container')
+  function ChessContainer() {
+    const root = h('div.ssb-chess-container');
     // root.title = location.page
-      // ? '/chess'
-      // : `/chess/${getRoot(location)}`
+    // ? '/chess'
+    // : `/chess/${getRoot(location)}`
 
     // root.id = api.app.sync.locationId(location)
-    
-    root.title = '/chess'
-    root.id = JSON.stringify({ page: 'chess' })
 
-    return root
+    root.title = '/chess';
+    root.id = JSON.stringify({ page: 'chess' });
+
+    return root;
   }
+};
+
+function locationId(location) {
+  if (location.page === 'chess') return JSON.stringify({ page: 'chess' });
+  if (isChessMsg(location)) return JSON.stringify({ page: 'chess' });
 }
 
-function locationId (location) {
-  if (location.page === 'chess') return JSON.stringify({ page: 'chess' })
-  if (isChessMsg(location)) return JSON.stringify({ page: 'chess' })
-}
-
-function isChessMsg (loc) {
+function isChessMsg(loc) {
   const type = get(loc, ['value', 'content', 'type'], '');
   return type.startsWith('chess');
 }
 
-function getRoot (msg) {
-  return get(msg, ['value', 'content', 'root'], msg.key)
+function getRoot(msg) {
+  return get(msg, ['value', 'content', 'root'], msg.key);
 }

--- a/main.js
+++ b/main.js
@@ -13,7 +13,7 @@ if (!process.argv.find(arg => arg === "cli")) {
   // be closed automatically when the JavaScript object is garbage collected.
   let mainWindow
 
-  function createWindow () {
+  const createWindow = function () {
     // Create the browser window.
     mainWindow = new BrowserWindow({width: 800, height: 600})
 

--- a/main.js
+++ b/main.js
@@ -1,89 +1,88 @@
-if (!process.argv.find(arg => arg === "cli")) {
-  const electron = require('electron')
+if (!process.argv.find(arg => arg === 'cli')) {
+  const electron = require('electron');
   // Module to control application life.
-  const app = electron.app
+  const app = electron.app;
 
   // Module to create native browser window.
-  const BrowserWindow = electron.BrowserWindow
+  const BrowserWindow = electron.BrowserWindow;
 
-  const path = require('path')
-  const url = require('url')
+  const path = require('path');
+  const url = require('url');
 
   // Keep a global reference of the window object, if you don't, the window will
   // be closed automatically when the JavaScript object is garbage collected.
-  let mainWindow
+  let mainWindow;
 
   const createWindow = function () {
     // Create the browser window.
-    mainWindow = new BrowserWindow({width: 800, height: 600})
+    mainWindow = new BrowserWindow({ width: 800, height: 600 });
 
     // and load the index.html of the app.
     mainWindow.loadURL(url.format({
       pathname: path.join(__dirname, 'index.html'),
       protocol: 'file:',
-      slashes: true
-    }))
+      slashes: true,
+    }));
 
     // Open the DevTools.
     // mainWindow.webContents.openDevTools()
 
     // Emitted when the window is closed.
-    mainWindow.on('closed', function () {
+    mainWindow.on('closed', () => {
       // Dereference the window object, usually you would store windows
       // in an array if your app supports multi windows, this is the time
       // when you should delete the corresponding element.
-      mainWindow = null
-    })
-  }
+      mainWindow = null;
+    });
+  };
 
   // This method will be called when Electron has finished
   // initialization and is ready to create browser windows.
   // Some APIs can only be used after this event occurs.
-  app.on('ready', createWindow)
+  app.on('ready', createWindow);
 
   // Quit when all windows are closed.
-  app.on('window-all-closed', function () {
+  app.on('window-all-closed', () => {
     // On OS X it is common for applications and their menu bar
     // to stay active until the user quits explicitly with Cmd + Q
     if (process.platform !== 'darwin') {
-      app.quit()
+      app.quit();
     }
-  })
+  });
 
-  app.on('activate', function () {
+  app.on('activate', () => {
     // On OS X it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.
     if (mainWindow === null) {
-      createWindow()
+      createWindow();
     }
-  })
+  });
 
   // In this file you can include the rest of your app's specific main process
   // code. You can also put them in separate files and require them here.
-
-}
-else {
-  var ssbClient = require('ssb-client');
-  var GameCtrl = require('./ctrl/game');
-  var CommandLine = require("./command_line");
-  var SocialCtrl = require("./ctrl/social");
+} else {
+  const ssbClient = require('ssb-client');
+  const GameCtrl = require('./ctrl/game');
+  const CommandLine = require('./command_line');
+  const SocialCtrl = require('./ctrl/social');
 
 
-  var Db = require("./db/init")();
+  const Db = require('./db/init')();
 
   ssbClient(
-    function (err, sbot) {
+    (err, sbot) => {
       if (err) {
         console.log(err);
       } else {
-        console.log("Starting ssb-chess");
-        sbot.whoami((err,ident) => {
-          Db.initDb().then(db => {
-              const gameCtrl = GameCtrl(sbot, ident.id, db);
-              const socialCtrl = SocialCtrl(sbot, ident.id);
-              const commandLine = CommandLine(gameCtrl, socialCtrl);
-          })
-        })
+        console.log('Starting ssb-chess');
+        sbot.whoami((err, ident) => {
+          Db.initDb().then((db) => {
+            const gameCtrl = GameCtrl(sbot, ident.id, db);
+            const socialCtrl = SocialCtrl(sbot, ident.id);
+            const commandLine = CommandLine(gameCtrl, socialCtrl);
+          });
+        });
       }
-    });
+    },
+  );
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "uuid": "3.1.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint . --fix",
+    "test": "eslint . --quiet",
     "start": "electron main.js",
     "rebuild": "npm rebuild --runtime=electron --target=$(electron -v) --abi=$(electron --abi) --disturl=https://atom.io/download/atom-shell",
     "postinstall": "npm rebuild"
@@ -39,6 +40,11 @@
   "homepage": "https://github.com/Happy0/ssb-chess",
   "license": "GPL-2.0",
   "devDependencies": {
-    "eslint": "^5.3.0"
+    "electron": "^2.0.7",
+    "eslint": "^5.3.0",
+    "eslint-config-airbnb": "^17.1.0",
+    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-plugin-import": "^2.14.0",
+    "ssb-client": "^4.5.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   },
   "author": "Gordon Martin",
   "homepage": "https://github.com/Happy0/ssb-chess",
-  "license": "GPL-2.0"
+  "license": "GPL-2.0",
+  "devDependencies": {
+    "eslint": "^5.3.0"
+  }
 }

--- a/ssb_ctrl/backlinks_obs.js
+++ b/ssb_ctrl/backlinks_obs.js
@@ -1,24 +1,23 @@
-var nest = require('depnest')
-var Value = require('mutant/value')
-var computed = require('mutant/computed')
-var Abortable = require('pull-abortable')
-var resolve = require('mutant/resolve')
-var pull = require('pull-stream')
-var onceIdle = require('mutant/once-idle')
+const nest = require('depnest');
+const Value = require('mutant/value');
+const computed = require('mutant/computed');
+const Abortable = require('pull-abortable');
+const resolve = require('mutant/resolve');
+const pull = require('pull-stream');
+const onceIdle = require('mutant/once-idle');
 
-var patchCore = require("patchcore")
-var combine = require("depject")
+const patchCore = require('patchcore');
+const combine = require('depject');
 
 /**
  * Mostly copied and pasted from backlinks.obs.for in the patchcore library
  * but with an optional parameter to filter messages
  */
 module.exports = () => {
+  const backlinksObs = {
+    needs: nest({ 'backlinks.obs.filter': 'first' }),
+  };
 
-  var backlinksObs = {
-    needs: nest({"backlinks.obs.filter": "first"})
-  }
-
-  var api = combine([backlinksObs, patchCore]);
+  const api = combine([backlinksObs, patchCore]);
   return api.backlinks.obs.filter[0];
-}
+};

--- a/ssb_ctrl/game.js
+++ b/ssb_ctrl/game.js
@@ -118,7 +118,7 @@ module.exports = (sbot, myIdent) => {
       }
     }
 
-  };
+  }
 
   /**
   * Returns 'true' if the given scuttlebutt message is something that changes

--- a/ssb_ctrl/game.js
+++ b/ssb_ctrl/game.js
@@ -1,61 +1,57 @@
-const filter = require('pull-stream/throughs/filter')
-const pull = require("pull-stream");
-const map = require("pull-stream/throughs/map");
-const collect = require("pull-stream/sinks/collect");
+const filter = require('pull-stream/throughs/filter');
+const pull = require('pull-stream');
+const map = require('pull-stream/throughs/map');
+const collect = require('pull-stream/sinks/collect');
 
 const nest = require('depnest');
 
-const computed = require("mutant/computed");
-const when = require("mutant/when");
-var Value = require('mutant/value')
-const onceTrue = require("mutant/once-true")
+const computed = require('mutant/computed');
+const when = require('mutant/when');
+const Value = require('mutant/value');
+const onceTrue = require('mutant/once-true');
 
-var SocialCtrl = require("./social");
-const MutantUtils = require("./mutant_utils")();
-const ChessMsgUtils = require ("../ssb_model/chess_msg_utils")();
+const SocialCtrl = require('./social');
+const MutantUtils = require('./mutant_utils')();
+const ChessMsgUtils = require('../ssb_model/chess_msg_utils')();
 
-const getFilteredBackLinks = require("./backlinks_obs")();
-const combine = require("depject");
+const getFilteredBackLinks = require('./backlinks_obs')();
+const combine = require('depject');
 
 module.exports = (sbot, myIdent) => {
-
   const socialCtrl = SocialCtrl(sbot);
 
   function getPlayers(gameRootMessage) {
     return new Promise((resolve, reject) => {
-      sbot.get(gameRootMessage, function(error, result) {
+      sbot.get(gameRootMessage, (error, result) => {
         if (error) {
-          reject(error)
+          reject(error);
         } else {
           const authorId = result.author;
           const invited = result.content.inviting;
 
-          const authorColour = result.content.myColor === "white" ? result.content.myColor : "black";
+          const authorColour = result.content.myColor === 'white' ? result.content.myColor : 'black';
           const players = {};
 
-          var names = Promise.all([authorId, invited].map(socialCtrl.getPlayerDisplayName));
-          names.then(names => {
+          const names = Promise.all([authorId, invited].map(socialCtrl.getPlayerDisplayName));
+          names.then((names) => {
             players[authorId] = {};
             players[authorId].colour = authorColour;
             players[authorId].name = names[0];
             players[authorId].id = authorId;
 
             players[invited] = {};
-            players[invited].colour = authorColour === "white" ? "black" : "white";
+            players[invited].colour = authorColour === 'white' ? 'black' : 'white';
             players[invited].name = names[1];
             players[invited].id = invited;
 
             resolve(players);
-
           });
         }
       });
-
-    })
+    });
   }
 
   function situationToSummary(gameSituation) {
-
     const summary = {
       gameId: gameSituation.gameId,
       fen: gameSituation.fen,
@@ -64,8 +60,8 @@ module.exports = (sbot, myIdent) => {
       status: gameSituation.status,
       lastMove: gameSituation.lastMove,
       check: gameSituation.check,
-      lastUpdateTime: gameSituation.lastUpdateTime
-    }
+      lastUpdateTime: gameSituation.lastUpdateTime,
+    };
 
     return summary;
   }
@@ -79,45 +75,42 @@ module.exports = (sbot, myIdent) => {
   }
 
   function findGameStatus(players, gameMessages) {
-    var gameFinishedMsg = gameMessages.find(msg => {
-      return msg.value.content.type === "chess_game_end"
-    });
+    const gameFinishedMsg = gameMessages.find(msg => msg.value.content.type === 'chess_game_end');
 
-    var inviteAcceptMsg = gameMessages.find(msg => msg.value.content.type === "chess_invite_accept");
+    const inviteAcceptMsg = gameMessages.find(msg => msg.value.content.type === 'chess_invite_accept');
 
-    var gameStatus = "invited";
+    let gameStatus = 'invited';
     if (gameFinishedMsg) {
       gameStatus = gameFinishedMsg.value.content.status;
     } else if (inviteAcceptMsg) {
-      gameStatus = "started";
+      gameStatus = 'started';
     }
 
 
     const status = {
       status: gameStatus,
-      winner: gameFinishedMsg != null ? ChessMsgUtils.winnerFromEndMsgPlayers(Object.keys(players), gameFinishedMsg) : null
-    }
+      winner: gameFinishedMsg != null ? ChessMsgUtils.winnerFromEndMsgPlayers(Object.keys(players), gameFinishedMsg) : null,
+    };
 
     return status;
   }
 
   function filterByPlayerMoves(players, messages) {
-    return messages.filter(msg => players.hasOwnProperty(msg.value.author) &&
-      (msg.value.content.type === "chess_move" ||
-        (msg.value.content.type === "chess_game_end" && msg.value.content.orig != null)));
+    return messages.filter(msg => players.hasOwnProperty(msg.value.author)
+      && (msg.value.content.type === 'chess_move'
+        || (msg.value.content.type === 'chess_game_end' && msg.value.content.orig != null)));
   }
 
   function getPlayerToMove(players, numMoves) {
-    const colourToMove = numMoves % 2 === 0 ? "white" : "black";
+    const colourToMove = numMoves % 2 === 0 ? 'white' : 'black';
 
     const playerIds = Object.keys(players);
 
-    for (var i = 0; i < playerIds.length; i++) {
+    for (let i = 0; i < playerIds.length; i++) {
       if (players[playerIds[i]].colour === colourToMove) {
         return playerIds[i];
       }
     }
-
   }
 
   /**
@@ -129,118 +122,115 @@ module.exports = (sbot, myIdent) => {
     if (!msg.value || !msg.value.content) {
       return false;
     }
-    else {
-      var relevantMessageTypes = [
-        "chess_invite",
-        "chess_invite_accept",
-        "chess_move",
-        "chess_game_end"];
 
-        var messageType = msg.value.content.type;
-        var isSituationMsg = relevantMessageTypes.find(msg => msg === messageType)
-        return isSituationMsg !== undefined;
-    }
+    const relevantMessageTypes = [
+      'chess_invite',
+      'chess_invite_accept',
+      'chess_move',
+      'chess_game_end'];
+
+    const messageType = msg.value.content.type;
+    const isSituationMsg = relevantMessageTypes.find(msg => msg === messageType);
+    return isSituationMsg !== undefined;
   }
 
   function getSituationObservable(gameRootMessage) {
     const gameMessages = getFilteredBackLinks(gameRootMessage, {
-        filter: isSituationalChessMessage
+      filter: isSituationalChessMessage,
     });
 
     const players = MutantUtils.promiseToMutant(getPlayers(gameRootMessage));
 
     return computed([players, gameMessages.sync, gameMessages],
-       (players, synced, messages) => {
-      if (!players || !synced) return null;
+      (players, synced, messages) => {
+        if (!players || !synced) return null;
 
-      // TODO: use an IDE that makes it easy to rename variables and rename 'msgs'
-      // to 'move messages';
-      var msgs = filterByPlayerMoves(players, messages);
-      if (!msgs) msgs = [];
-      if (!messages) messages = [];
+        // TODO: use an IDE that makes it easy to rename variables and rename 'msgs'
+        // to 'move messages';
+        let msgs = filterByPlayerMoves(players, messages);
+        if (!msgs) msgs = [];
+        if (!messages) messages = [];
 
-      // Sort in ascending ply so that we get a list of moves linearly
-      msgs = msgs.sort((a, b) => a.value.content.ply - b.value.content.ply);
+        // Sort in ascending ply so that we get a list of moves linearly
+        msgs = msgs.sort((a, b) => a.value.content.ply - b.value.content.ply);
 
-      var latestUpdate = messages.reduce(msgWithBiggestTimestamp, null) ;
+        const latestUpdate = messages.reduce(msgWithBiggestTimestamp, null);
 
-      var startFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+        const startFen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 
-      var pgnMoves = msgs.map(msg => msg.value.content.pgnMove);
-      var fenHistory = msgs.map(msg => msg.value.content.fen);
-      fenHistory.unshift(startFen);
+        const pgnMoves = msgs.map(msg => msg.value.content.pgnMove);
+        const fenHistory = msgs.map(msg => msg.value.content.fen);
+        fenHistory.unshift(startFen);
 
-      var status = findGameStatus(players, messages);
+        const status = findGameStatus(players, messages);
 
-      var origDests = msgs.map(msg => ({
-        'orig': msg.value.content.orig,
-        'dest': msg.value.content.dest
-      }));
+        const origDests = msgs.map(msg => ({
+          orig: msg.value.content.orig,
+          dest: msg.value.content.dest,
+        }));
 
-      var isCheck = msgs.length > 0 ? msgs[msgs.length - 1].value.content.pgnMove.indexOf('+') !== -1 : false;
-      var isCheckmate = msgs.length > 0 ? msgs[msgs.length - 1].value.content.pgnMove.indexOf('#') !== -1 : false;
+        const isCheck = msgs.length > 0 ? msgs[msgs.length - 1].value.content.pgnMove.indexOf('+') !== -1 : false;
+        const isCheckmate = msgs.length > 0 ? msgs[msgs.length - 1].value.content.pgnMove.indexOf('#') !== -1 : false;
 
-      return {
-        gameId: gameRootMessage,
-        pgnMoves: pgnMoves,
-        fenHistory: fenHistory,
-        ply: pgnMoves.length,
-        origDests: origDests,
-        check: isCheck || isCheckmate,
-        fen: msgs.length > 0 ? msgs[msgs.length - 1].value.content.fen : startFen,
-        players: players,
-        toMove: getPlayerToMove(players, pgnMoves.length),
-        status: status,
-        lastMove: origDests.length > 0 ? origDests[origDests.length - 1] : null,
-        lastUpdateTime: latestUpdate ? latestUpdate.value.timestamp : 0,
-        latestUpdateMsg: latestUpdate ? latestUpdate.key : gameRootMessage,
-        isCheckOnMoveNumber: function(moveNumber) {
-          var arrIdx = moveNumber - 1;
-          return this.pgnMoves[arrIdx] != null && (this.pgnMoves[arrIdx].indexOf("+") !== -1 || this.pgnMoves[arrIdx].indexOf("#") !== -1);
-        },
-        getInitialFen: function () {
-          return startFen;
-        },
-        getWhitePlayer: function () {
-          return Object.values(this.players).find(player => player.colour === "white");
-        },
-        getBlackPlayer: function () {
-          return Object.values(this.players).find(player => player.colour === "black");
-        },
-        hasPlayer: function (id) {
-          return this.players[id] != null;
-        },
-        getOtherPlayer: function (id) {
-          for (var k in this.players) {
-            if (k !== id) {
-              return this.players[k];
+        return {
+          gameId: gameRootMessage,
+          pgnMoves,
+          fenHistory,
+          ply: pgnMoves.length,
+          origDests,
+          check: isCheck || isCheckmate,
+          fen: msgs.length > 0 ? msgs[msgs.length - 1].value.content.fen : startFen,
+          players,
+          toMove: getPlayerToMove(players, pgnMoves.length),
+          status,
+          lastMove: origDests.length > 0 ? origDests[origDests.length - 1] : null,
+          lastUpdateTime: latestUpdate ? latestUpdate.value.timestamp : 0,
+          latestUpdateMsg: latestUpdate ? latestUpdate.key : gameRootMessage,
+          isCheckOnMoveNumber(moveNumber) {
+            const arrIdx = moveNumber - 1;
+            return this.pgnMoves[arrIdx] != null && (this.pgnMoves[arrIdx].indexOf('+') !== -1 || this.pgnMoves[arrIdx].indexOf('#') !== -1);
+          },
+          getInitialFen() {
+            return startFen;
+          },
+          getWhitePlayer() {
+            return Object.values(this.players).find(player => player.colour === 'white');
+          },
+          getBlackPlayer() {
+            return Object.values(this.players).find(player => player.colour === 'black');
+          },
+          hasPlayer(id) {
+            return this.players[id] != null;
+          },
+          getOtherPlayer(id) {
+            for (const k in this.players) {
+              if (k !== id) {
+                return this.players[k];
+              }
             }
-          }
-        }
-      }
-    });
+          },
+        };
+      });
   }
 
   function msgWithBiggestTimestamp(msg1, msg2) {
     if (msg1 == null) {
       return msg2;
-    } else if (msg2 == null) {
+    } if (msg2 == null) {
       return msg1;
-    } else if (msg1.value.timestamp > msg2.value.timestamp) {
+    } if (msg1.value.timestamp > msg2.value.timestamp) {
       return msg1;
-    } else {
-      return msg2;
     }
+    return msg2;
   }
 
   function getSituationSummaryObservable(gameRootMessage) {
-    return computed([getSituationObservable(gameRootMessage)], situation => {
+    return computed([getSituationObservable(gameRootMessage)], (situation) => {
       if (situation == null) {
         return null;
-      } else {
-        return situationToSummary(situation);
       }
-    })
+      return situationToSummary(situation);
+    });
   }
 
   function getSituation(gameRootMessage) {
@@ -250,100 +240,96 @@ module.exports = (sbot, myIdent) => {
   function makeMove(gameRootMessage, ply, originSquare, destinationSquare, promotion, pgnMove, fen, respondsTo) {
     const post = {
       type: 'chess_move',
-      ply: ply,
+      ply,
       root: gameRootMessage,
       orig: originSquare,
       dest: destinationSquare,
-      pgnMove: pgnMove,
-      fen: fen
-    }
+      pgnMove,
+      fen,
+    };
 
     if (promotion) {
-      post['promotion'] = promotion;
+      post.promotion = promotion;
     }
 
     if (respondsTo) {
-      post['branch'] = respondsTo
+      post.branch = respondsTo;
     }
 
     return new Promise((resolve, reject) => {
-
-      sbot.publish(post, function(err, msg) {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(msg);
-        }
-      });
-    })
-  }
-
-  function addPropertyIfNotEmpty(obj, key, value) {
-    if (value) {
-      obj[key] = value
-    }
-  }
-
-  function resignGame(gameRootMessage, respondsTo) {
-    const post = {
-      type: 'chess_game_end',
-      status: "resigned",
-      root: gameRootMessage
-    };
-
-    addPropertyIfNotEmpty(post, "branch", respondsTo);
-
-    return new Promise( (resolve, reject) => {
       sbot.publish(post, (err, msg) => {
         if (err) {
           reject(err);
         } else {
           resolve(msg);
         }
-      })
-    })
+      });
+    });
   }
 
-  function endGame(gameRootMessage, status, winner, fen, ply, originSquare, destinationSquare, pgnMove, respondsTo) {
+  function addPropertyIfNotEmpty(obj, key, value) {
+    if (value) {
+      obj[key] = value;
+    }
+  }
+
+  function resignGame(gameRootMessage, respondsTo) {
+    const post = {
+      type: 'chess_game_end',
+      status: 'resigned',
+      root: gameRootMessage,
+    };
+
+    addPropertyIfNotEmpty(post, 'branch', respondsTo);
+
     return new Promise((resolve, reject) => {
-
-      const post = {
-        type: 'chess_game_end',
-        status: status,
-        ply: ply,
-        fen: fen,
-        root: gameRootMessage
-      };
-
-      // If game aborted or agreed to draw / claimed draw, some of these
-      // properties might not be relevant
-      addPropertyIfNotEmpty(post, "winner", winner);
-      addPropertyIfNotEmpty(post, "ply", ply);
-      addPropertyIfNotEmpty(post, "orig", originSquare);
-      addPropertyIfNotEmpty(post, "dest", destinationSquare);
-      addPropertyIfNotEmpty(post, "pgnMove", pgnMove);
-      addPropertyIfNotEmpty(post, "branch", respondsTo)
-
-      sbot.publish(post, function(err, msg) {
+      sbot.publish(post, (err, msg) => {
         if (err) {
           reject(err);
         } else {
           resolve(msg);
         }
       });
+    });
+  }
 
+  function endGame(gameRootMessage, status, winner, fen, ply, originSquare, destinationSquare, pgnMove, respondsTo) {
+    return new Promise((resolve, reject) => {
+      const post = {
+        type: 'chess_game_end',
+        status,
+        ply,
+        fen,
+        root: gameRootMessage,
+      };
+
+      // If game aborted or agreed to draw / claimed draw, some of these
+      // properties might not be relevant
+      addPropertyIfNotEmpty(post, 'winner', winner);
+      addPropertyIfNotEmpty(post, 'ply', ply);
+      addPropertyIfNotEmpty(post, 'orig', originSquare);
+      addPropertyIfNotEmpty(post, 'dest', destinationSquare);
+      addPropertyIfNotEmpty(post, 'pgnMove', pgnMove);
+      addPropertyIfNotEmpty(post, 'branch', respondsTo);
+
+      sbot.publish(post, (err, msg) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(msg);
+        }
+      });
     });
   }
 
   return {
-    getPlayers: getPlayers,
-    getSituation: getSituation,
-    getSituationObservable: getSituationObservable,
-    getSituationSummaryObservable: getSituationSummaryObservable,
-    getSmallGameSummary: getSmallGameSummary,
-    makeMove: makeMove,
-    resignGame: resignGame,
-    endGame: endGame
-  }
-
-}
+    getPlayers,
+    getSituation,
+    getSituationObservable,
+    getSituationSummaryObservable,
+    getSmallGameSummary,
+    makeMove,
+    resignGame,
+    endGame,
+  };
+};

--- a/ssb_ctrl/game_challenge.js
+++ b/ssb_ctrl/game_challenge.js
@@ -1,61 +1,57 @@
-const pull = require("pull-stream");
+const pull = require('pull-stream');
 const About = require('ssb-ooo-about');
 const Promise = require('bluebird');
 
 module.exports = (sbot, myIdent) => {
-
-  var about = About(sbot, {});
-  var getLatestAboutMsgIds = Promise.promisify(about.async.getLatestMsgIds);
+  const about = About(sbot, {});
+  const getLatestAboutMsgIds = Promise.promisify(about.async.getLatestMsgIds);
 
   function inviteToPlay(invitingPubKey, asWhite) {
-
     return new Promise((resolve, reject) => {
-
       // Give some messages that give both player's latest 'about' messages
       // so that their name (about about) can be displayed to spectators who
       // don't have one of the players in their follow graph using ssb-ooo.
-      var aboutMsgs = Promise.all(
+      const aboutMsgs = Promise.all(
         [
           getLatestAboutMsgIds(invitingPubKey),
-          getLatestAboutMsgIds(myIdent)
-        ]).then(arr => arr.reduce((a, b) => a.concat(b), []));
+          getLatestAboutMsgIds(myIdent),
+        ],
+      ).then(arr => arr.reduce((a, b) => a.concat(b), []));
 
-      aboutMsgs.then(aboutInfo => {
+      aboutMsgs.then((aboutInfo) => {
         const post = {
-          'type': 'chess_invite',
-          'inviting': invitingPubKey,
-          'myColor': asWhite ? 'white' : 'black'
-        }
+          type: 'chess_invite',
+          inviting: invitingPubKey,
+          myColor: asWhite ? 'white' : 'black',
+        };
 
         if (aboutInfo && aboutInfo.length != 0) {
-          post['branch'] = aboutInfo;
+          post.branch = aboutInfo;
         }
 
-        sbot.publish(post, function(err, msg) {
+        sbot.publish(post, (err, msg) => {
           if (err) {
             reject(err);
           } else {
             resolve(msg);
           }
         });
-
       });
-
     });
   }
 
   function acceptChallenge(gameRootMessage) {
-    console.log("Accepting challenge. Root game message is: " + gameRootMessage);
+    console.log(`Accepting challenge. Root game message is: ${gameRootMessage}`);
     const post = {
-      'type': 'chess_invite_accept',
-      'root': gameRootMessage,
+      type: 'chess_invite_accept',
+      root: gameRootMessage,
       // Used for ssb-ooo which allows clients to request messages from peers
       // that are outside their follow graph.
-      'branch': gameRootMessage
-    }
+      branch: gameRootMessage,
+    };
 
     return new Promise((resolve, reject) => {
-      sbot.publish(post, function(err, msg) {
+      sbot.publish(post, (err, msg) => {
         if (err) {
           reject(err);
         } else {
@@ -66,7 +62,7 @@ module.exports = (sbot, myIdent) => {
   }
 
   return {
-    inviteToPlay: inviteToPlay,
-    acceptChallenge: acceptChallenge
-  }
-}
+    inviteToPlay,
+    acceptChallenge,
+  };
+};

--- a/ssb_ctrl/mutant_utils.js
+++ b/ssb_ctrl/mutant_utils.js
@@ -1,31 +1,29 @@
-var Value = require('mutant/value')
-var onceTrue = require('mutant/once-true');
+const Value = require('mutant/value');
+const onceTrue = require('mutant/once-true');
 
 module.exports = () => {
-
   function promiseToMutant(promise) {
-    var mutant = Value();
+    const mutant = Value();
 
-    promise.then(mutant.set).catch(err => {throw err} /* gadz */);
+    promise.then(mutant.set).catch((err) => { throw err; } /* gadz */);
 
     return mutant;
   }
 
   function mutantToPromise(mutant) {
-    return new Promise ( (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       try {
-        onceTrue(mutant, v => {
+        onceTrue(mutant, (v) => {
           resolve(v);
-        })
+        });
       } catch (e) {
         reject(e);
       }
-
     });
   }
 
   return {
-    promiseToMutant: promiseToMutant,
-    mutantToPromise: mutantToPromise
-  }
-}
+    promiseToMutant,
+    mutantToPromise,
+  };
+};

--- a/ssb_ctrl/social.js
+++ b/ssb_ctrl/social.js
@@ -1,15 +1,14 @@
-const pull = require("pull-stream");
+const pull = require('pull-stream');
 
 module.exports = (sbot, myIdent) => {
-
   // untested
   function followPlayer(playerPubKey) {
     sbot.publish({
       type: 'contact',
       contact: playerPubKey,
-      following: true
-    }, function(err, msg) {
-      console.log("Following contact: " + console.dir(msg));
+      following: true,
+    }, (err, msg) => {
+      console.log(`Following contact: ${console.dir(msg)}`);
     });
   }
 
@@ -18,10 +17,10 @@ module.exports = (sbot, myIdent) => {
     sbot.publish({
       type: 'contact',
       contact: playerPubKey,
-      following: false
-    }, function(err, msg) {
-      console.log("Unfollowing contact: " + console.dir(msg));
-    })
+      following: false,
+    }, (err, msg) => {
+      console.log(`Unfollowing contact: ${console.dir(msg)}`);
+    });
   }
 
   function consumeStreamIntoArrayPromise(source, through) {
@@ -33,38 +32,37 @@ module.exports = (sbot, myIdent) => {
           resolve(results);
         }
       }));
-    })
-
+    });
   }
 
   function followedByMe() {
-    var followsMe = sbot.links({
+    const followsMe = sbot.links({
       source: myIdent,
-      rel: "contact",
+      rel: 'contact',
       values: true,
-      reverse: true
+      reverse: true,
     });
 
-    var onlyStillFollowingsThrough = pull(
+    const onlyStillFollowingsThrough = pull(
       pull.unique('dest'),
-      pull.filter(msg => msg.value.content.following !== false)
+      pull.filter(msg => msg.value.content.following !== false),
     );
 
     return consumeStreamIntoArrayPromise(followsMe, onlyStillFollowingsThrough)
-            .then(results => results.map(a => a.dest));
+      .then(results => results.map(a => a.dest));
   }
 
   function followingMe() {
-    var followsMe = sbot.links({
+    const followsMe = sbot.links({
       dest: myIdent,
-      rel: "contact",
+      rel: 'contact',
       values: true,
-      reverse: true
+      reverse: true,
     });
 
-    var onlyStillFollowingsThrough = pull(
+    const onlyStillFollowingsThrough = pull(
       pull.unique('source'),
-      pull.filter(msg => msg.value.content.following !== false)
+      pull.filter(msg => msg.value.content.following !== false),
     );
 
     return consumeStreamIntoArrayPromise(followsMe, onlyStillFollowingsThrough)
@@ -72,20 +70,20 @@ module.exports = (sbot, myIdent) => {
   }
 
   function getPlayerDisplayName(playerPubKey) {
-    //console.log("uwot " + playerPubKey);
+    // console.log("uwot " + playerPubKey);
 
     // TODO: have some way to mark a game as corrupted.
     if (!playerPubKey || !playerPubKey.startsWith('@')) {
-      return Promise.resolve("<error>");
+      return Promise.resolve('<error>');
     }
 
-    //console.log("player pub key:" + playerPubKey);
+    // console.log("player pub key:" + playerPubKey);
     const aboutStream = sbot.links({
       dest: playerPubKey,
-      rel: "about",
+      rel: 'about',
       reverse: true,
       values: true,
-      source: playerPubKey
+      source: playerPubKey,
     });
 
     return new Promise((resolve, reject) => {
@@ -101,11 +99,10 @@ module.exports = (sbot, myIdent) => {
   }
 
   return {
-    followingMe: followingMe,
-    followedByMe: followedByMe,
-    followPlayer: followPlayer,
-    unfollowPlayer: unfollowPlayer,
-    getPlayerDisplayName: getPlayerDisplayName
-  }
-
-}
+    followingMe,
+    followedByMe,
+    followPlayer,
+    unfollowPlayer,
+    getPlayerDisplayName,
+  };
+};

--- a/ssb_model/chess_msg_utils.js
+++ b/ssb_model/chess_msg_utils.js
@@ -1,33 +1,33 @@
 module.exports = () => {
-
   function winnerFromEndMsg(invite, maybeGameEndMsg) {
     if (!invite || !maybeGameEndMsg) {
       return null;
     }
-    var players = [invite.value.author, invite.value.content.inviting];
+    const players = [invite.value.author, invite.value.content.inviting];
     return winnerFromEndMsgPlayers(players, maybeGameEndMsg);
   }
 
   function winnerFromEndMsgPlayers(players, maybeGameEndMsg) {
+    let winner;
+
     if (!maybeGameEndMsg || !players) {
       return null;
-    } else {
-      switch(maybeGameEndMsg.value.content.status) {
-        case "mate":
-          return maybeGameEndMsg.value.author;
-        case "draw":
-          return null;
-        case "resigned":
-          var winner = players.filter(playerId => playerId != maybeGameEndMsg.value.author)[0];
-          return winner;
-        default:
-          return null;
-      }
+    }
+    switch (maybeGameEndMsg.value.content.status) {
+      case 'mate':
+        return maybeGameEndMsg.value.author;
+      case 'draw':
+        return null;
+      case 'resigned':
+        winner = players.filter(playerId => playerId != maybeGameEndMsg.value.author)[0];
+        return winner;
+      default:
+        return null;
     }
   }
 
   return {
-    winnerFromEndMsg: winnerFromEndMsg,
-    winnerFromEndMsgPlayers: winnerFromEndMsgPlayers
-  }
-}
+    winnerFromEndMsg,
+    winnerFromEndMsgPlayers,
+  };
+};

--- a/ui/challenge/challenge_control.js
+++ b/ui/challenge/challenge_control.js
@@ -1,17 +1,16 @@
 const m = require('mithril');
 
 module.exports = (gameCtrl) => {
-
-  var challengableFriends = [];
+  let challengableFriends = [];
 
   function renderFriendOption(friend) {
     return m('option', {
-      value: friend.ident
+      value: friend.ident,
     }, friend.displayName);
   }
 
   function sortChallengeableFriendsAlphabetically() {
-    challengableFriends.sort(function(a, b) {
+    challengableFriends.sort((a, b) => {
       if (a.displayName.toLowerCase() < b.displayName.toLowerCase()) return -1;
       if (a.displayName.toLowerCase() > b.displayName.toLowerCase()) return 1;
       return 0;
@@ -22,37 +21,37 @@ module.exports = (gameCtrl) => {
     sortChallengeableFriendsAlphabetically();
 
     return m('select', {
-      id: "ssb-chess-challenge-control",
-      name: 'friends'
+      id: 'ssb-chess-challenge-control',
+      name: 'friends',
     }, challengableFriends.map(renderFriendOption));
   }
 
   function renderChallengeControl() {
     const invitePlayer = (e) => {
-      var buttonElement = e.srcElement;
-      buttonElement.disabled = true
+      const buttonElement = e.srcElement;
+      buttonElement.disabled = true;
 
-      var inviteDropdown = document.getElementById("ssb-chess-challenge-control");
-      var friendId = inviteDropdown.options[inviteDropdown.selectedIndex].value;
+      const inviteDropdown = document.getElementById('ssb-chess-challenge-control');
+      const friendId = inviteDropdown.options[inviteDropdown.selectedIndex].value;
 
       gameCtrl.inviteToPlay(friendId)
-        .then(msg => m.route.set("/games/" + btoa(msg.key)))
+        .then(msg => m.route.set(`/games/${btoa(msg.key)}`))
         .then(() => buttonElement.disabled = false);
-    }
+    };
 
     const challengeButton = m('button', {
-      onclick: invitePlayer
+      onclick: invitePlayer,
     }, 'Challenge');
 
     return m('div', {
-      class: "ssb-chess-challenge-control"
+      class: 'ssb-chess-challenge-control',
     }, [renderFriendsdropDown(), challengeButton]);
   }
 
   function updateFriends() {
     // Using palaroonis as a variable name because it's my project and
     // nobody can stop me >=D #madlad
-    gameCtrl.getSocialCtrl().friendsWithNames().then(palaroonis => {
+    gameCtrl.getSocialCtrl().friendsWithNames().then((palaroonis) => {
       challengableFriends = palaroonis;
     }).then(m.redraw);
   }
@@ -62,7 +61,6 @@ module.exports = (gameCtrl) => {
 
     oncreate: () => {
       updateFriends();
-    }
-  }
-
-}
+    },
+  };
+};

--- a/ui/export/pgnExport.js
+++ b/ui/export/pgnExport.js
@@ -1,36 +1,32 @@
-var m = require('mithril');
+const m = require('mithril');
 
 module.exports = (gameId, pgnString) => {
+  function informationText() {
+    return m('div', { class: 'ssb-chess-import-pgn-advice' }, [
+      m('div', 'A chess PGN can be exported to another program chess for computer assisted game analysis. '),
+      m('span', "If you are online, I recommend lichess.org's analysis tools which can recommend stronger moves and show you your mistakes. "),
+      m('span', 'You can import your PGN here: '),
+      m('a', { href: 'https://lichess.org/paste' }, 'https://lichess.org/paste'),
+      m('span', ". There are offline tools available but I haven't used any."),
+    ]);
+  }
 
-    function informationText() {
-      return m('div', {class: 'ssb-chess-import-pgn-advice'}, [
-        m('div', "A chess PGN can be exported to another program chess for computer assisted game analysis. "),
-        m('span', "If you are online, I recommend lichess.org's analysis tools which can recommend stronger moves and show you your mistakes. "),
-        m('span', "You can import your PGN here: "),
-        m('a', {href: "https://lichess.org/paste"}, "https://lichess.org/paste"),
-        m('span', ". There are offline tools available but I haven't used any.")
-      ])
-    }
+  function pgnBox() {
+    return m('div', { class: 'ssb-chess-pgn-text-box-container' },
+      m('textarea', { class: 'ssb-chess-pgn-text-box' }, pgnString));
+  }
 
-    function pgnBox() {
-      return m('div', {class: 'ssb-chess-pgn-text-box-container'},
-                m('textarea', { class: 'ssb-chess-pgn-text-box' }, pgnString)
-              );
-    }
+  function goBackButton() {
+    const goBackToGame = () => m.route.set(`/games/${btoa(gameId)}`);
 
-    function goBackButton() {
-      var goBackToGame = () => m.route.set("/games/" + btoa(gameId));
+    return m('button', { class: 'ssb-chess-pgn-export-back-button', title: 'Go back to game', onclick: goBackToGame }, 'Go back to game');
+  }
 
-      return m('button', {class: 'ssb-chess-pgn-export-back-button', title: "Go back to game", onclick: goBackToGame}, "Go back to game");
-    }
-
-    return {
-      view: () => {
-        return m('div', {class: 'ssb-chess-pgn-export'}, [
-          informationText(),
-          pgnBox(),
-          goBackButton()
-        ])
-      }
-    }
-}
+  return {
+    view: () => m('div', { class: 'ssb-chess-pgn-export' }, [
+      informationText(),
+      pgnBox(),
+      goBackButton(),
+    ]),
+  };
+};

--- a/ui/game/PieceGraveyard.js
+++ b/ui/game/PieceGraveyard.js
@@ -1,9 +1,9 @@
-var m = require("mithril");
-var watchAll = require("mutant/watch-all");
+const m = require('mithril');
+const watchAll = require('mutant/watch-all');
 
-var opposite = require('chessground/util').opposite;
+const opposite = require('chessground/util').opposite;
 
-var R = require('ramda');
+const R = require('ramda');
 
 /**
  * A view of the pieces of the differences in pieces compared to the other
@@ -23,24 +23,28 @@ module.exports = (
   situationObservable,
   moveSelectedObservable,
   myIdent,
-  bottom) => {
+  bottom,
+) => {
+  let materialDiff = {};
 
-  var materialDiff = {};
-
-  var playerColour = null;
-  var opponentColor = null;
+  let playerColour = null;
+  let opponentColor = null;
 
   // Copied from lila (lichess) and translated to JavaScript from typescript :P
   // https://github.com/ornicar/lila/blob/c72ca979a846304a772e1c4f2b0d1851b076849d/ui/round/src/util.ts#L49
   function getMaterialDiff(pieces) {
-
-    var diff = {
-      white: { king: 0, queen: 0, rook: 0, bishop: 0, knight: 0, pawn: 0 },
-      black: { king: 0, queen: 0, rook: 0, bishop: 0, knight: 0, pawn: 0 },
+    const diff = {
+      white: {
+        king: 0, queen: 0, rook: 0, bishop: 0, knight: 0, pawn: 0,
+      },
+      black: {
+        king: 0, queen: 0, rook: 0, bishop: 0, knight: 0, pawn: 0,
+      },
     };
 
-    for (let k in pieces) {
-      const p = pieces[k], them = diff[opposite(p.color)];
+    for (const k in pieces) {
+      const p = pieces[k]; const
+        them = diff[opposite(p.color)];
       if (them[p.role] > 0) them[p.role]--;
       else diff[p.color][p.role]++;
     }
@@ -49,48 +53,46 @@ module.exports = (
   }
 
   function setPlayerColours(situation) {
-      playerColour = situation.players[myIdent] ? situation.players[myIdent].colour : 'white';
-      opponentColor = playerColour === "white" ? "black" : "white";
+    playerColour = situation.players[myIdent] ? situation.players[myIdent].colour : 'white';
+    opponentColor = playerColour === 'white' ? 'black' : 'white';
   }
 
   function renderPiecesForColour(colour) {
-    var pieces = [];
+    let pieces = [];
 
-    for (var pieceName in materialDiff[colour]) {
-      var numPieces = materialDiff[colour][pieceName];
-      var repeated = R.repeat(pieceName, numPieces);
+    for (const pieceName in materialDiff[colour]) {
+      const numPieces = materialDiff[colour][pieceName];
+      const repeated = R.repeat(pieceName, numPieces);
 
       pieces = pieces.concat(repeated);
     }
 
-    return pieces.map(p => m('mono-piece', {class: p}));
+    return pieces.map(p => m('mono-piece', { class: p }));
   }
 
   return {
-    view: () => {
-      return m("div", {
-        class: "ssb-chess-graveyard",
-      }, bottom ? renderPiecesForColour(playerColour) : renderPiecesForColour(opponentColor))
-    },
+    view: () => m('div', {
+      class: 'ssb-chess-graveyard',
+    }, bottom ? renderPiecesForColour(playerColour) : renderPiecesForColour(opponentColor)),
     oncreate: () => {
       this.removeWatches = watchAll([chessGroundObservable, situationObservable, moveSelectedObservable],
-         (chessground, situation, move) => {
-        if (situation) {
-          setPlayerColours(situation);
-        }
+        (chessground, situation, move) => {
+          if (situation) {
+            setPlayerColours(situation);
+          }
 
-        if (chessground) {
-          var pieces = chessground.state.pieces;
-          materialDiff = getMaterialDiff(pieces);
-          m.redraw();
-        }
-      });
+          if (chessground) {
+            const pieces = chessground.state.pieces;
+            materialDiff = getMaterialDiff(pieces);
+            m.redraw();
+          }
+        });
     },
     onremove: () => {
       if (this.removeWatches) {
         this.removeWatches();
       }
-    }
+    },
 
-  }
-}
+  };
+};

--- a/ui/game/gameActions.js
+++ b/ui/game/gameActions.js
@@ -1,82 +1,78 @@
-var m = require("mithril");
-var onceTrue = require('mutant/once-true');
-var Value = require('mutant/value');
-var when = require('mutant/when');
-var watch = require("mutant/watch");
-var computed = require('mutant/computed');
+const m = require('mithril');
+const onceTrue = require('mutant/once-true');
+const Value = require('mutant/value');
+const when = require('mutant/when');
+const watch = require('mutant/watch');
+const computed = require('mutant/computed');
 
 module.exports = (gameMoveCtrl, myIdent, situationObservable) => {
+  let watchesToClear = [];
 
-  var watchesToClear = [];
+  let observing = true;
 
-  var observing = true;
-
-  var moveConfirmationObservable = makeMoveObservationListener();
+  const moveConfirmationObservable = makeMoveObservationListener();
 
   function moveConfirmButtons() {
-
-    var confirmMove = () => {
+    const confirmMove = () => {
       moveConfirmationObservable.set({
         moveNeedsConfirmed: false,
-        confirmed: true
-      })
-    }
+        confirmed: true,
+      });
+    };
 
-    var cancelMove = () => {
+    const cancelMove = () => {
       moveConfirmationObservable.set({
         moveNeedsConfirmed: false,
-        confirmed: false
-      })
-    }
+        confirmed: false,
+      });
+    };
 
     return m('div', {
-      class: 'ssb-chess-move-confirm-buttons'
+      class: 'ssb-chess-move-confirm-buttons',
     }, [
       m('button', {
-        onclick: confirmMove
+        onclick: confirmMove,
       }, 'Confirm'),
       m('button', {
-        onclick: cancelMove
-      }, 'Cancel')
-    ])
+        onclick: cancelMove,
+      }, 'Cancel'),
+    ]);
   }
 
   function resignButton() {
-    var resignGame = (e) => {
+    const resignGame = (e) => {
       onceTrue(situationObservable,
-        situation => {
-          if (situation && situation.status.status === "started") {
-            gameMoveCtrl.resignGame(situation.gameId, situation.latestUpdateMsg)
+        (situation) => {
+          if (situation && situation.status.status === 'started') {
+            gameMoveCtrl.resignGame(situation.gameId, situation.latestUpdateMsg);
           }
-        }
-      );
-    }
+        });
+    };
 
     return m('button', {
-      onclick: resignGame
+      onclick: resignGame,
     }, 'Resign');
   }
 
   function handlePgnExport(gameId) {
-    var url = "/games/:gameId/pgn";
+    const url = '/games/:gameId/pgn';
 
     m.route.set(url, {
-      gameId: btoa(gameId)
+      gameId: btoa(gameId),
     });
   }
 
   function postGameButtons() {
-
     const exportPgn = () => {
-      onceTrue(situationObservable, situation => {
-        handlePgnExport(situation.gameId)
+      onceTrue(situationObservable, (situation) => {
+        handlePgnExport(situation.gameId);
       });
-    }
+    };
 
     return m('button', {
       onclick: exportPgn,
-      title: 'Export game.'
-    }, 'Export game')
+      title: 'Export game.',
+    }, 'Export game');
   }
 
   function isObserving(situation) {
@@ -84,11 +80,11 @@ module.exports = (gameMoveCtrl, myIdent, situationObservable) => {
   }
 
   function makeMoveObservationListener() {
-    var value = Value();
+    const value = Value();
 
     value.set({
       moveNeedsConfirmed: false,
-      moveConfirmed: false
+      moveConfirmed: false,
     });
 
     return value;
@@ -98,14 +94,13 @@ module.exports = (gameMoveCtrl, myIdent, situationObservable) => {
     // Eh, miby there's redundancy here, dunno :P
 
     return computed(moveConfirmationObservable,
-      confirmation => confirmation.moveNeedsConfirmed
-    );
+      confirmation => confirmation.moveNeedsConfirmed);
   }
 
   function usualButtons() {
-    var gameInProgress = computed(
+    const gameInProgress = computed(
       situationObservable,
-      situation => situation && (situation.status.status === "started")
+      situation => situation && (situation.status.status === 'started'),
     );
 
     return when(gameInProgress, resignButton(), postGameButtons());
@@ -113,22 +108,18 @@ module.exports = (gameMoveCtrl, myIdent, situationObservable) => {
 
   return {
     view: (vDom) => {
-
       if (observing) {
         return postGameButtons();
       }
-      else {
-        return m('div', {
-            class: "ssb-game-actions"
-          },
-          when(moveNeedsConfirmed(), moveConfirmButtons(), usualButtons())()
-        );
-      }
+
+      return m('div', {
+        class: 'ssb-game-actions',
+      },
+      when(moveNeedsConfirmed(), moveConfirmButtons(), usualButtons())());
     },
-    oninit: function(vNode) {
-      var w = watch(situationObservable,
-        (situation) => observing = isObserving(situation)
-      );
+    oninit(vNode) {
+      const w = watch(situationObservable,
+        situation => observing = isObserving(situation));
 
       watchesToClear.push(w);
     },
@@ -136,22 +127,22 @@ module.exports = (gameMoveCtrl, myIdent, situationObservable) => {
       watchesToClear.forEach(w => w());
       watchesToClear = [];
     },
-    showMoveConfirmation: function() {
+    showMoveConfirmation() {
       moveConfirmationObservable.set({
         moveNeedsConfirmed: true,
-        confirmed: false
+        confirmed: false,
       });
 
       return moveConfirmationObservable;
     },
-    hideMoveConfirmation: function() {
+    hideMoveConfirmation() {
       moveConfirmationObservable.set({
         moveNeedsConfirmed: false,
-        confirmed: false
+        confirmed: false,
       });
 
       m.redraw();
-    }
+    },
 
-  }
-}
+  };
+};

--- a/ui/game/gameHistory.js
+++ b/ui/game/gameHistory.js
@@ -1,112 +1,109 @@
-const Value = require("mutant/value");
-const m = require("mithril");
-const watch = require("mutant/watch");
+const Value = require('mutant/value');
+const m = require('mithril');
+const watch = require('mutant/watch');
 
-const R = require("ramda");
+const R = require('ramda');
 
 // todo: move this file somewhere more appropriate :P
-const PlayerModelUtils = require("../../ctrl/player_model_utils")();
+const PlayerModelUtils = require('../../ctrl/player_model_utils')();
 
 const UserLocationUtils = require('../viewer_perspective/user_location')();
 
 module.exports = (gameObservable, myIdent) => {
+  let watchesToClear = [];
 
-  var watchesToClear = [];
-
-  var moveNumberSelected = "live";
+  let moveNumberSelected = 'live';
   const moveSelectedObservable = Value(moveNumberSelected);
 
-  var pgnMoves = [];
-  var status = null;
-  var players = [];
+  let pgnMoves = [];
+  let status = null;
+  let players = [];
 
-  var latestMove = 0;
+  let latestMove = 0;
 
   function renderPlayerName(player) {
-    return m('a[href=/player/' + btoa(player.id) + ']', {
-        oncreate: m.route.link
-      },
-      player.name.substring(0, 10));
+    return m(`a[href=/player/${btoa(player.id)}]`, {
+      oncreate: m.route.link,
+    },
+    player.name.substring(0, 10));
   }
 
   function renderPlayers() {
-    if (!players || players.length === 0 ) {
-      return m('div', {}, "");
+    if (!players || players.length === 0) {
+      return m('div', {}, '');
     }
 
-    var mePlaying = players[myIdent];
-    var myPerspectiveColour = mePlaying ? mePlaying.colour : "white";
+    const mePlaying = players[myIdent];
+    const myPerspectiveColour = mePlaying ? mePlaying.colour : 'white';
 
-    var coloursToPlayers = PlayerModelUtils.coloursToPlayer(players);
+    const coloursToPlayers = PlayerModelUtils.coloursToPlayer(players);
 
-    var whitePlayer = coloursToPlayers["white"];
-    var blackPlayer = coloursToPlayers["black"];
-    return m('div', {class: "ssb-chess-history-player-container"}, [
-      m('div', {class: "ssb-chess-history-player"}, renderPlayerName(whitePlayer)),
-      m('div', {class: "ssb-chess-history-player"}, renderPlayerName(blackPlayer))
+    const whitePlayer = coloursToPlayers.white;
+    const blackPlayer = coloursToPlayers.black;
+    return m('div', { class: 'ssb-chess-history-player-container' }, [
+      m('div', { class: 'ssb-chess-history-player' }, renderPlayerName(whitePlayer)),
+      m('div', { class: 'ssb-chess-history-player' }, renderPlayerName(blackPlayer)),
     ]);
   }
 
   function renderStatus() {
     if (!status) {
-      return m('div', "");
+      return m('div', '');
     }
 
     switch (status.status) {
-      case "invited":
-        return  m('div', {class: "ssb-chess-status-text"}, "Awaiting invite being accepted.");
-      case "resigned":
-        return m('div', {class: "ssb-chess-status-text"},
-          players[status.winner].name + " wins by resignation.");
-      case "mate":
-        return m('div', {class: "ssb-chess-status-text"},
-          players[status.winner].name + " wins.");
-      case "draw":
-        return m('div', {class: "ssb-chess-status-text"}, "Draw.")
+      case 'invited':
+        return m('div', { class: 'ssb-chess-status-text' }, 'Awaiting invite being accepted.');
+      case 'resigned':
+        return m('div', { class: 'ssb-chess-status-text' },
+          `${players[status.winner].name} wins by resignation.`);
+      case 'mate':
+        return m('div', { class: 'ssb-chess-status-text' },
+          `${players[status.winner].name} wins.`);
+      case 'draw':
+        return m('div', { class: 'ssb-chess-status-text' }, 'Draw.');
       default:
         return m('div');
     }
-
   }
 
   function renderHistory() {
     return m('div', {
-      class: ''
+      class: '',
     }, [renderPlayers(), renderMoveHistory(), renderStatus()]);
   }
 
   function renderHalfMove(pgn, moveNumber) {
     const clickHandler = () => {
-
       if (moveNumber === latestMove) {
-        moveNumberSelected = "live";
+        moveNumberSelected = 'live';
       } else {
         moveNumberSelected = moveNumber;
       }
 
       moveSelectedObservable.set(moveNumberSelected);
-    }
+    };
 
-    var highlightClass = ((moveNumberSelected === moveNumber) ||
-      (moveNumber === latestMove && moveNumberSelected === "live")) ? " ssb-chess-pgn-move-selected" : "";
+    const highlightClass = ((moveNumberSelected === moveNumber)
+      || (moveNumber === latestMove && moveNumberSelected === 'live')) ? ' ssb-chess-pgn-move-selected' : '';
 
     return m('div', {
-      class: "ssb-chess-pgn-cell" + highlightClass,
-      onclick: clickHandler
+      class: `ssb-chess-pgn-cell${highlightClass}`,
+      onclick: clickHandler,
     }, pgn);
   }
 
   function renderMoveHistory() {
     const halves = R.splitEvery(2, pgnMoves);
 
-    return m('div', {class: 'ssb-chess-pgn-moves-list'},
+    return m('div', { class: 'ssb-chess-pgn-moves-list' },
       halves.map((half, halfNumber) => m('div', {
-        class: 'ssb-chess-pgn-move'
-    }, [renderHalfMove(half[0], ((halfNumber + 1) * 2) - 1), renderHalfMove(half[1], (halfNumber + 1) * 2)])));
+        class: 'ssb-chess-pgn-move',
+      }, [renderHalfMove(half[0], ((halfNumber + 1) * 2) - 1), renderHalfMove(half[1], (halfNumber + 1) * 2)])));
   }
 
   function hasChatInputBoxFocused() {
-    return document.activeElement.className.indexOf("ssb-embedded-chat-input-box") > -1;
+    return document.activeElement.className.indexOf('ssb-embedded-chat-input-box') > -1;
   }
 
   function handleArrowKeys() {
@@ -115,40 +112,38 @@ module.exports = (gameObservable, myIdent) => {
     const right = 39;
     const down = 40;
 
-    document.onkeydown = function(evt) {
-
+    document.onkeydown = function (evt) {
       if (!UserLocationUtils.chessAppIsVisible() || hasChatInputBoxFocused()) {
         return;
       }
 
       evt = evt || window.event;
       if (evt.keyCode === left && (moveNumberSelected !== 0)) {
-        if (moveNumberSelected === "live") {
+        if (moveNumberSelected === 'live') {
           moveNumberSelected = latestMove;
         }
 
-        moveNumberSelected = moveNumberSelected - 1;
-      } else if (evt.keyCode === right && moveNumberSelected !== "live") {
-        moveNumberSelected = moveNumberSelected + 1;
+        moveNumberSelected -= 1;
+      } else if (evt.keyCode === right && moveNumberSelected !== 'live') {
+        moveNumberSelected += 1;
 
         if (moveNumberSelected === latestMove) {
-          moveNumberSelected = "live";
+          moveNumberSelected = 'live';
         }
-
       } else if (evt.keyCode === up) {
         moveNumberSelected = 0;
       } else if (evt.keyCode === down) {
-        moveNumberSelected = "live";
+        moveNumberSelected = 'live';
       }
 
-      var allArrowKeys = [left, up, right, down];
+      const allArrowKeys = [left, up, right, down];
 
       if (allArrowKeys.indexOf(evt.keyCode) !== -1) {
         moveSelectedObservable.set(moveNumberSelected);
       }
 
       m.redraw();
-    }
+    };
   }
 
   /**
@@ -161,8 +156,8 @@ module.exports = (gameObservable, myIdent) => {
   }
 
   function scrollToBottomIfLive() {
-    if (moveNumberSelected === "live") {
-      var moveListElement = document.getElementsByClassName("ssb-chess-pgn-moves-list")[0];
+    if (moveNumberSelected === 'live') {
+      const moveListElement = document.getElementsByClassName('ssb-chess-pgn-moves-list')[0];
       if (moveListElement) {
         moveListElement.scrollTop = moveListElement.scrollHeight;
       }
@@ -170,7 +165,7 @@ module.exports = (gameObservable, myIdent) => {
   }
 
   function updateModelOnGameUpdates() {
-    var w = watch(gameObservable, (situation) => {
+    const w = watch(gameObservable, (situation) => {
       if (situation) {
         pgnMoves = situation.pgnMoves;
         status = situation.status;
@@ -184,12 +179,12 @@ module.exports = (gameObservable, myIdent) => {
   }
 
   function goToLiveMode() {
-    moveNumberSelected = "live";
+    moveNumberSelected = 'live';
     moveSelectedObservable.set(moveNumberSelected);
   }
 
   function scrollToBottomOnGameUpdates() {
-    var w = watch(gameObservable, (situation) => {
+    const w = watch(gameObservable, (situation) => {
       scrollToBottomIfLive();
       m.redraw();
     });
@@ -210,8 +205,7 @@ module.exports = (gameObservable, myIdent) => {
       watchesToClear.forEach(w => w());
       watchesToClear = [];
     },
-    getMoveSelectedObservable: getMoveSelectedObservable,
-    goToLiveMode: goToLiveMode
-  }
-
-}
+    getMoveSelectedObservable,
+    goToLiveMode,
+  };
+};

--- a/ui/game/promote.js
+++ b/ui/game/promote.js
@@ -1,29 +1,28 @@
 const m = require('mithril');
 
 module.exports = (chessBoardDomElement, colour, column, onChoice) => {
-
-  const roles = ["queen", "rook", "knight", "bishop"];
+  const roles = ['queen', 'rook', 'knight', 'bishop'];
 
   function renderPiece(role, cb) {
     return m('piece', {
-      class: colour + ' ' + role,
-      onclick: () => cb(role)
+      class: `${colour} ${role}`,
+      onclick: () => cb(role),
     });
   }
 
   const PromotionBox = (cb) => {
-    var component = {
+    const component = {
       view: () => m('div', {
-        id: "ssb-promotion-box"
+        id: 'ssb-promotion-box',
       }, [
         m('div', {
-          id: "ssb-promotion-box-pieces"
-        }, roles.map(role => renderPiece(role, cb)))
-      ])
-    }
+          id: 'ssb-promotion-box-pieces',
+        }, roles.map(role => renderPiece(role, cb))),
+      ]),
+    };
 
     return component;
-  }
+  };
 
 
   function columnLetterToNumberFromZero(columnLetter) {
@@ -31,20 +30,20 @@ module.exports = (chessBoardDomElement, colour, column, onChoice) => {
   }
 
   function renderPromotionOptionsOverlay() {
-    var chessBoardDomElement = document.getElementsByClassName("cg-board-wrap")[0];
+    const chessBoardDomElement = document.getElementsByClassName('cg-board-wrap')[0];
 
-    var prom = document.createElement('div');
+    const prom = document.createElement('div');
 
-    var cb = (piece) => {
+    const cb = (piece) => {
       chessBoardDomElement.removeChild(prom);
       onChoice(piece);
-    }
+    };
 
-    var box = PromotionBox(cb);
+    const box = PromotionBox(cb);
 
-    var left = colour === "white" ? 75 * columnLetterToNumberFromZero(column) : ((75 * 7) - (75 * columnLetterToNumberFromZero(column)));
-    var promotionBox = m('div', {
-      style: 'z-index: 100; position: absolute; left: ' + left + 'px; top: 0px;'
+    const left = colour === 'white' ? 75 * columnLetterToNumberFromZero(column) : ((75 * 7) - (75 * columnLetterToNumberFromZero(column)));
+    const promotionBox = m('div', {
+      style: `z-index: 100; position: absolute; left: ${left}px; top: 0px;`,
     }, m(box));
 
     chessBoardDomElement.appendChild(prom);
@@ -53,6 +52,6 @@ module.exports = (chessBoardDomElement, colour, column, onChoice) => {
   }
 
   return {
-    renderPromotionOptionsOverlay: renderPromotionOptionsOverlay
-  }
-}
+    renderPromotionOptionsOverlay,
+  };
+};

--- a/ui/invitations/invitations.js
+++ b/ui/invitations/invitations.js
@@ -82,7 +82,7 @@ module.exports = (gameCtrl) => {
 
   function renderMiniboards(invites, sent, title) {
 
-    var title = m('div', {
+    var titleDiv = m('div', {
       class: "ssb-chess-invites-section-title"
     }, title);
 
@@ -94,7 +94,7 @@ module.exports = (gameCtrl) => {
 
     )
 
-    return m('div', {}, [title, miniboards]);
+    return m('div', {}, [titleDiv, miniboards]);
   }
 
   return {

--- a/ui/miniboard/miniboard.js
+++ b/ui/miniboard/miniboard.js
@@ -1,80 +1,76 @@
-var m = require('mithril');
-var Chessground = require('chessground').Chessground;
-var PlayerModelUtils = require('../../ctrl/player_model_utils')();
-var timeAgo = require('./timeAgo')()
+const m = require('mithril');
+const Chessground = require('chessground').Chessground;
+const PlayerModelUtils = require('../../ctrl/player_model_utils')();
+const timeAgo = require('./timeAgo')();
 
 module.exports = (gameSummaryObservable, summary, identPerspective, opts) => {
+  let chessground = null;
+  let observables = [];
+  let lastActivityTimestamp = summary.lastUpdateTime;
 
-  var chessground = null;
-  var observables = [];
-  var lastActivityTimestamp = summary.lastUpdateTime;
-
-  var timeAgoRedrawTimer = null;
+  const timeAgoRedrawTimer = null;
 
   // An observer might not be in the 'players' list so we need a default
   // perspective of white for them.
-  const playerColour = (summary.players[identPerspective] &&
-    summary.players[identPerspective].colour) ? summary.players[identPerspective].colour : "white";
+  const playerColour = (summary.players[identPerspective]
+    && summary.players[identPerspective].colour) ? summary.players[identPerspective].colour : 'white';
 
   function renderPlayerName(player) {
-    return m('a[href=/player/' + btoa(player.id) + ']', {
-        class: "ssb-chess-miniboard-name",
-        oncreate: m.route.link
-      },
-      player.name.substring(0, 10));
+    return m(`a[href=/player/${btoa(player.id)}]`, {
+      class: 'ssb-chess-miniboard-name',
+      oncreate: m.route.link,
+    },
+    player.name.substring(0, 10));
   }
 
   function renderSummaryBottom() {
     if (!(opts && opts.small)) {
-      var coloursNames = PlayerModelUtils.coloursToPlayer(summary.players);
-      var otherPlayerColour = playerColour == "white" ? "black" : "white";
+      const coloursNames = PlayerModelUtils.coloursToPlayer(summary.players);
+      const otherPlayerColour = playerColour == 'white' ? 'black' : 'white';
 
-      var leftPlayer = coloursNames[playerColour];
-      var rightPlayer = coloursNames[otherPlayerColour];
+      const leftPlayer = coloursNames[playerColour];
+      const rightPlayer = coloursNames[otherPlayerColour];
 
       return m('div', {
-        class: 'ssb-chess-miniboard-bottom'
+        class: 'ssb-chess-miniboard-bottom',
       }, [m('center', {
-          class: "ssb-chess-miniboard-name"
-        }, renderPlayerName(leftPlayer)),
-        m('small', {
-          class: 'ssb-chess-miniboard-time-ago'
-        }, lastActivityTimestamp ? timeAgo(lastActivityTimestamp)(): ""),
-        m('center', {
-          class: "ssb-chess-miniboard-name"
-        }, renderPlayerName(rightPlayer))
-      ])
-
-    } else {
-      return m('div');
+        class: 'ssb-chess-miniboard-name',
+      }, renderPlayerName(leftPlayer)),
+      m('small', {
+        class: 'ssb-chess-miniboard-time-ago',
+      }, lastActivityTimestamp ? timeAgo(lastActivityTimestamp)() : ''),
+      m('center', {
+        class: 'ssb-chess-miniboard-name',
+      }, renderPlayerName(rightPlayer)),
+      ]);
     }
+    return m('div');
   }
 
   function renderSummary() {
-
-    var observing = Object.keys(summary.players).indexOf(identPerspective) === -1;
-    var boardSizeClass = opts && opts.small ? "ssb-chess-board-small" : "ssb-chess-board-medium";
+    const observing = Object.keys(summary.players).indexOf(identPerspective) === -1;
+    const boardSizeClass = opts && opts.small ? 'ssb-chess-board-small' : 'ssb-chess-board-medium';
 
     return m('div', {
-      class: "ssb-chess-miniboard ssb-chess-board-background-blue3 merida"
+      class: 'ssb-chess-miniboard ssb-chess-board-background-blue3 merida',
     }, [
-      m('a[href=' + '/games/' + btoa(summary.gameId) + "?observing=" + observing + ']', {
-        class: "ssb-chessground-container cg-board-wrap " + boardSizeClass,
+      m(`${'a[href=/games/'}${btoa(summary.gameId)}?observing=${observing}]`, {
+        class: `ssb-chessground-container cg-board-wrap ${boardSizeClass}`,
         title: summary.gameId,
         id: summary.gameId,
-        oncreate: m.route.link
-      }), renderSummaryBottom()
+        oncreate: m.route.link,
+      }), renderSummaryBottom(),
     ]);
   }
 
   function summaryToChessgroundConfig(summary) {
-    var config = {
+    const config = {
       fen: summary.fen,
       viewOnly: true,
       orientation: playerColour,
       turnColor: summary.players[summary.toMove].colour,
       check: summary.check,
-      coordinates: false
+      coordinates: false,
     };
 
     if (summary.lastMove) {
@@ -85,39 +81,37 @@ module.exports = (gameSummaryObservable, summary, identPerspective, opts) => {
   }
 
   return {
-    view: function() {
+    view() {
       return renderSummary();
     },
-    oncreate: function(vNode) {
-
+    oncreate(vNode) {
       // This lifecycle event tells us that the DOM is ready. That means we
       // can attach chessground to our chessground container element that was
       // prepared for it during the 'view' lifecycle method.
 
-      var config = summaryToChessgroundConfig(summary);
+      const config = summaryToChessgroundConfig(summary);
 
-      var dom = vNode.dom;
-      var chessGroundParent = dom.querySelector(".ssb-chessground-container");
+      const dom = vNode.dom;
+      const chessGroundParent = dom.querySelector('.ssb-chessground-container');
       chessground = Chessground(chessGroundParent, config);
 
       // Listen for game updates
 
-      var situationObs = gameSummaryObservable(newSummary => {
-        var newConfig = summaryToChessgroundConfig(newSummary);
+      const situationObs = gameSummaryObservable((newSummary) => {
+        const newConfig = summaryToChessgroundConfig(newSummary);
         chessground.set(newConfig);
-        lastActivityTimestamp = newSummary.lastUpdateTime
+        lastActivityTimestamp = newSummary.lastUpdateTime;
       });
 
       observables.push(situationObs);
     },
-    onremove: function() {
+    onremove() {
       if (chessground) {
         chessground.destroy();
       }
 
       observables.forEach(w => w());
       observables = [];
-    }
-  }
-
-}
+    },
+  };
+};

--- a/ui/miniboard/miniboard_list.js
+++ b/ui/miniboard/miniboard_list.js
@@ -1,8 +1,8 @@
-var m = require("mithril");
-var Chessground = require('chessground').Chessground;
-var Miniboard = require('./miniboard');
+const m = require('mithril');
+const Chessground = require('chessground').Chessground;
+const watch = require('mutant/watch');
+const Miniboard = require('./miniboard');
 
-var watch = require("mutant/watch");
 
 /**
  * Takes an observable list of game summaries (non-observable inner objects)
@@ -14,45 +14,42 @@ var watch = require("mutant/watch");
  * game ends or begins on a page of games a user is playing.)
  */
 module.exports = (gameCtrl, gameSummaryListObs, ident) => {
-  var gameSummaries = [];
+  let gameSummaries = [];
 
-  var oneMinuteMillseconds = 60000;
+  const oneMinuteMillseconds = 60000;
 
   this.ident = ident;
 
-  var unlistenUpdates = null;
+  let unlistenUpdates = null;
 
   function keepMiniboardsUpdated() {
-    unlistenUpdates = watch(gameSummaryListObs, summaries => {
+    unlistenUpdates = watch(gameSummaryListObs, (summaries) => {
       gameSummaries = summaries;
-      setTimeout(m.redraw)
+      setTimeout(m.redraw);
     });
   }
 
   return {
-    view: () => {
-      return m("div", {
-          class: "ssb-chess-miniboards"
-        },
-        gameSummaries.map(summary => {
-          var situationObservable = gameCtrl.getSituationSummaryObservable(summary.gameId);
-
-          return m(
-            Miniboard(situationObservable, summary, this.ident)
-          )
-        })
-      )
+    view: () => m('div', {
+      class: 'ssb-chess-miniboards',
     },
-    oncreate: function(e) {
+    gameSummaries.map((summary) => {
+      const situationObservable = gameCtrl.getSituationSummaryObservable(summary.gameId);
+
+      return m(
+        Miniboard(situationObservable, summary, this.ident),
+      );
+    })),
+    oncreate(e) {
       keepMiniboardsUpdated();
 
       this.updateTimeAgoTimes = setInterval(
-        () => setTimeout(m.redraw), oneMinuteMillseconds
+        () => setTimeout(m.redraw), oneMinuteMillseconds,
       );
     },
     onremove: () => {
       clearInterval(this.updateTimeAgoTimes);
       unlistenUpdates();
-    }
-  }
-}
+    },
+  };
+};

--- a/ui/miniboard/timeAgo.js
+++ b/ui/miniboard/timeAgo.js
@@ -1,14 +1,13 @@
-var patchCore = require('patchcore')
-var combine = require('depject')
-var nest = require('depnest')
+const patchCore = require('patchcore');
+const combine = require('depject');
+const nest = require('depnest');
 
 module.exports = () => {
+  const timeAgo = {
+    needs: nest({ 'lib.obs.timeAgo': 'first' }),
+  };
 
-  var timeAgo = {
-    needs: nest({"lib.obs.timeAgo": "first"})
-  }
+  const api = combine([timeAgo, patchCore]);
 
-  var api = combine([timeAgo, patchCore]);
-
-  return api.lib.obs.timeAgo[0]
-}
+  return api.lib.obs.timeAgo[0];
+};

--- a/ui/notify/notifier.js
+++ b/ui/notify/notifier.js
@@ -1,68 +1,61 @@
-var UserGamesWatcher = require('../../ctrl/user_game_updates_watcher');
-var notify = require('./notify')();
-var pull = require('pull-stream');
-var userLocationUtils = require('../viewer_perspective/user_location')();
-var onceTrue = require('mutant/once-true');
+const UserGamesWatcher = require('../../ctrl/user_game_updates_watcher');
+const notify = require('./notify')();
+const pull = require('pull-stream');
+const userLocationUtils = require('../viewer_perspective/user_location')();
+const onceTrue = require('mutant/once-true');
 
 module.exports = (gameCtrl, sbot) => {
-
-  var me = gameCtrl.getMyIdent();
+  const me = gameCtrl.getMyIdent();
 
   userGamesWatcher = UserGamesWatcher(sbot);
 
   function notifyIfRelevant(gameMsg) {
-
     if (!userLocationUtils.chessAppIsVisible()) {
-
-      var gameId = gameMsg.value.content.type === "chess_invite" ? gameMsg.key : gameMsg.value.content.root;
+      const gameId = gameMsg.value.content.type === 'chess_invite' ? gameMsg.key : gameMsg.value.content.root;
 
       if (!gameId) {
         return;
       }
 
-      var situation = gameCtrl.getSituationObservable(gameId);
+      const situation = gameCtrl.getSituationObservable(gameId);
 
-      onceTrue(situation, function (gameSituation) {
+      onceTrue(situation, (gameSituation) => {
+        const opponentName = getOpponentName(gameSituation, gameMsg);
+        let notification;
 
-        var opponentName = getOpponentName(gameSituation, gameMsg);
-        var notification;
-
-        if (gameMsg.value.content && gameMsg.value.content.type === "chess_invite" && gameMsg.value.author != me) {
-          notification = opponentName + " has invited you to a game";
+        if (gameMsg.value.content && gameMsg.value.content.type === 'chess_invite' && gameMsg.value.author != me) {
+          notification = `${opponentName} has invited you to a game`;
+          notify.showNotification(notification);
+        } else if (gameMsg.value.content.type === 'chess_move' && gameMsg.value.author != me) {
+          notification = `It's your move in your game against ${opponentName}`;
+          notify.showNotification(notification);
+        } else if (gameMsg.value.content.type === 'chess_game_end' && gameMsg.value.author != me) {
+          notification = `Your game with ${opponentName} ended`;
+          notify.showNotification(notification);
+        } else if (gameMsg.value.content.type === 'chess_invite_accept' && gameMsg.value.author != me) {
+          notification = `${opponentName} has accepted your game invite`;
           notify.showNotification(notification);
         }
-        else if (gameMsg.value.content.type === "chess_move" && gameMsg.value.author != me) {
-          notification = "It's your move in your game against " + opponentName;
-          notify.showNotification(notification);
-        } else if (gameMsg.value.content.type === "chess_game_end" && gameMsg.value.author != me) {
-          notification = "Your game with " + opponentName + " ended";
-          notify.showNotification(notification);
-        } else if (gameMsg.value.content.type === "chess_invite_accept" && gameMsg.value.author != me) {
-          notification = opponentName + " has accepted your game invite";
-          notify.showNotification(notification);
-        }
-
-      })
-
+      });
     }
   }
 
   function getOpponentName(situation, msg) {
-    return situation.players[msg.value.author] ? situation.players[msg.value.author].name : "";
+    return situation.players[msg.value.author] ? situation.players[msg.value.author].name : '';
   }
 
   function startNotifying() {
-    var opts = {
+    const opts = {
       live: true,
-      since: Date.now()
+      since: Date.now(),
     };
 
-    var gameUpdateStream = userGamesWatcher.chessMessagesForPlayerGames(gameCtrl.getMyIdent(), opts);
+    const gameUpdateStream = userGamesWatcher.chessMessagesForPlayerGames(gameCtrl.getMyIdent(), opts);
 
-    pull(gameUpdateStream, pull.drain((msg) => notifyIfRelevant(msg)));
+    pull(gameUpdateStream, pull.drain(msg => notifyIfRelevant(msg)));
   }
 
   return {
-    startNotifying: startNotifying
-  }
-}
+    startNotifying,
+  };
+};

--- a/ui/notify/notifier.js
+++ b/ui/notify/notifier.js
@@ -25,19 +25,20 @@ module.exports = (gameCtrl, sbot) => {
       onceTrue(situation, function (gameSituation) {
 
         var opponentName = getOpponentName(gameSituation, gameMsg);
+        var notification;
 
         if (gameMsg.value.content && gameMsg.value.content.type === "chess_invite" && gameMsg.value.author != me) {
-          var notification = opponentName + " has invited you to a game";
+          notification = opponentName + " has invited you to a game";
           notify.showNotification(notification);
         }
         else if (gameMsg.value.content.type === "chess_move" && gameMsg.value.author != me) {
-          var notification = "It's your move in your game against " + opponentName;
+          notification = "It's your move in your game against " + opponentName;
           notify.showNotification(notification);
         } else if (gameMsg.value.content.type === "chess_game_end" && gameMsg.value.author != me) {
-          var notification = "Your game with " + opponentName + " ended";
+          notification = "Your game with " + opponentName + " ended";
           notify.showNotification(notification);
         } else if (gameMsg.value.content.type === "chess_invite_accept" && gameMsg.value.author != me) {
-          var notification = opponentName + " has accepted your game invite";
+          notification = opponentName + " has accepted your game invite";
           notify.showNotification(notification);
         }
 

--- a/ui/notify/notify.js
+++ b/ui/notify/notify.js
@@ -1,34 +1,31 @@
 module.exports = () => {
-
   function displayNotification(text, onclick) {
-    var options = {
+    const options = {
       body: text,
-      requireInteraction: true
-    }
+      requireInteraction: true,
+    };
 
-    var n = new Notification("Scuttlebutt Chess", options);
+    const n = new Notification('Scuttlebutt Chess', options);
 
     if (onclick) {
-        n.onclick = onclick;
+      n.onclick = onclick;
     }
   }
 
   function showNotification(text, onclick) {
-    var permission = Notification.permission;
-    if (permission === "default") {
-
-      Notification.requestPermission().then(result => {
-        if (result === "granted") {
+    const permission = Notification.permission;
+    if (permission === 'default') {
+      Notification.requestPermission().then((result) => {
+        if (result === 'granted') {
           displayNotification(text);
         }
       });
-
-    } else if (permission === "granted") {
+    } else if (permission === 'granted') {
       displayNotification(text, onclick);
     }
   }
 
   return {
-    showNotification: showNotification
-  }
-}
+    showNotification,
+  };
+};

--- a/ui/pageLayout/navigation.js
+++ b/ui/pageLayout/navigation.js
@@ -2,118 +2,109 @@ const m = require('mithril');
 const SettingsDialog = require('../settings/settings-dialog');
 
 module.exports = (gameCtrl, settings) => {
-
   const gamesInProgress = {
-    name: "Games",
-    link: "/my_games",
+    name: 'Games',
+    link: '/my_games',
     count: 0,
-    countHoverText: () => `You have ${gamesInProgress.count} games in progress.`
+    countHoverText: () => `You have ${gamesInProgress.count} games in progress.`,
   };
   const gamesMyMove = {
-    name: "My Move",
-    link: "/games_my_move",
+    name: 'My Move',
+    link: '/games_my_move',
     count: 0,
     countUpdateFn: gameCtrl.getGamesWhereMyMove,
-    countHoverText: () => `${gamesMyMove.count} games awaiting your move.`
+    countHoverText: () => `${gamesMyMove.count} games awaiting your move.`,
   };
   const invitations = {
     name: 'Invitations',
-    link: "/invitations",
+    link: '/invitations',
     count: 0,
     countUpdateFn: gameCtrl.pendingChallengesReceived,
-    countHoverText: () => `${invitations.count} pending invitations received.`
+    countHoverText: () => `${invitations.count} pending invitations received.`,
   };
   const observable = {
     name: 'Observe',
-    link: "/observable",
+    link: '/observable',
     count: 0,
     countUpdateFn: gameCtrl.getFriendsObservableGames,
     countOnHoverOnly: true,
-    countHoverText: () => `${observable.count} observable games.`
+    countHoverText: () => `${observable.count} observable games.`,
   };
   const recent = {
     name: 'Recent Activity',
     link: '/activity',
     count: 0,
     countUpdateFn: gameCtrl.getRecentActivityCtrl().unseenNotifications,
-    countHoverText: () => 'Recent Activity'
-  }
+    countHoverText: () => 'Recent Activity',
+  };
 
-  var navItems = [gamesInProgress, gamesMyMove, invitations, observable, recent];
+  const navItems = [gamesInProgress, gamesMyMove, invitations, observable, recent];
 
   function renderNavItem(navItem) {
     return m('span', {
-      class: 'ssb-chess-nav-item'
-    }, m("a[href=" + navItem.link + "]", {
-        oncreate: m.route.link,
-        title: navItem.countHoverText()
-      },
+      class: 'ssb-chess-nav-item',
+    }, m(`a[href=${navItem.link}]`, {
+      oncreate: m.route.link,
+      title: navItem.countHoverText(),
+    },
 
-      [m('span', navItem.name),
-        m('span', {
-          style: (navItem.countOnHoverOnly || navItem.count === 0) ? 'display: none' : '',
-          class: 'ssb-chess-nav-count'
-        }, `(${navItem.count})`)
-      ]));
+    [m('span', navItem.name),
+      m('span', {
+        style: (navItem.countOnHoverOnly || navItem.count === 0) ? 'display: none' : '',
+        class: 'ssb-chess-nav-count',
+      }, `(${navItem.count})`),
+    ]));
   }
 
-  var closeSettingsDialog = () => {
-    var dialogElementId = 'ssb-chess-settings-dialog';
-    var element = document.getElementById(dialogElementId);
+  const closeSettingsDialog = () => {
+    const dialogElementId = 'ssb-chess-settings-dialog';
+    const element = document.getElementById(dialogElementId);
 
     if (element) {
       element.parentNode.removeChild(element);
     }
-  }
+  };
 
-  var showSettings = () => {
-
-    var element = document.getElementById('ssb-chess-settings-dialog');
+  const showSettings = () => {
+    const element = document.getElementById('ssb-chess-settings-dialog');
 
     if (!element) {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       container.id = 'ssb-chess-settings-dialog';
 
-      var settingsDialog = SettingsDialog(settings, closeSettingsDialog);
+      const settingsDialog = SettingsDialog(settings, closeSettingsDialog);
 
       document.body.appendChild(container);
       m.render(container, m(settingsDialog));
     }
-
-  }
+  };
 
   function renderNavigation() {
     return m('div', [
       navItems.map(renderNavItem),
-      m('a', {id: 'ssb-chess-settings-nav-item', href: "#", onclick: showSettings}, 'SETTINGS')
+      m('a', { id: 'ssb-chess-settings-nav-item', href: '#', onclick: showSettings }, 'SETTINGS'),
     ]);
   }
 
   function keepCountsUpdated() {
-
-    navItems.forEach(navItem => {
+    navItems.forEach((navItem) => {
       if (navItem.countUpdateFn) {
-
-        navItem.countUpdateFn()(items => {
-          var numItems = items.length;
+        navItem.countUpdateFn()((items) => {
+          const numItems = items.length;
           navItem.count = numItems;
           m.redraw();
-        })
-
+        });
       }
-    })
-
+    });
   }
 
   return {
-    view: () => {
-      return renderNavigation();
-    },
+    view: () => renderNavigation(),
     oncreate: () => {
       keepCountsUpdated();
     },
     onremove: () => {
 
-    }
-  }
-}
+    },
+  };
+};

--- a/ui/player/player_games.js
+++ b/ui/player/player_games.js
@@ -1,21 +1,20 @@
 const Scroller = require('pull-scroll');
-var h = require('hyperscript');
-var m = require('mithril');
-var pull = require('pull-stream');
+const h = require('hyperscript');
+const m = require('mithril');
+const pull = require('pull-stream');
 
-var Miniboard = require('../miniboard/miniboard');
+const Miniboard = require('../miniboard/miniboard');
 
 module.exports = (gameCtrl) => {
-
   function renderFinishedGameSummary(gameSummary, playerId) {
-    var dom = document.createElement('div');
-    dom.className = "ssb-chess-profile-game-summary";
+    const dom = document.createElement('div');
+    dom.className = 'ssb-chess-profile-game-summary';
 
-    var gameSummaryObservable = gameCtrl.getSituationSummaryObservable(gameSummary.gameId);
+    const gameSummaryObservable = gameCtrl.getSituationSummaryObservable(gameSummary.gameId);
 
-    var miniboard = Miniboard(gameSummaryObservable, gameSummary, playerId);
+    const miniboard = Miniboard(gameSummaryObservable, gameSummary, playerId);
 
-    var board = m(miniboard);
+    const board = m(miniboard);
 
     m.render(dom, board);
 
@@ -25,31 +24,30 @@ module.exports = (gameCtrl) => {
   function getScrollingFinishedGamesDom(playerId) {
     const finishedGamesSource = gameCtrl.getPlayerCtrl().endedGamesSummariesSource(playerId);
 
-    var content = h('div', {
-      className: "ssb-chess-player-finished-games-scroller"
-    })
+    const content = h('div', {
+      className: 'ssb-chess-player-finished-games-scroller',
+    });
 
-    var scroller = h('div', {
+    const scroller = h('div', {
       style: {
         'overflow-y': 'scroll',
         position: 'fixed',
         bottom: '0px',
         top: '200px',
-        width: '100%'
+        width: '100%',
       },
-    }, content)
+    }, content);
 
     pull(finishedGamesSource,
-      Scroller(scroller, content, (current) => renderFinishedGameSummary(current, playerId))
-    );
+      Scroller(scroller, content, current => renderFinishedGameSummary(current, playerId)));
 
     return h('div', {
-      className: 'ssb-chess-player-finished-games'
+      className: 'ssb-chess-player-finished-games',
     }, scroller);
   }
 
 
   return {
-    getScrollingFinishedGamesDom: getScrollingFinishedGamesDom
-  }
-}
+    getScrollingFinishedGamesDom,
+  };
+};

--- a/ui/player/player_profile.js
+++ b/ui/player/player_profile.js
@@ -1,39 +1,31 @@
-var m = require('mithril');
-var PlayerGames = require('./player_games');
+const m = require('mithril');
+const PlayerGames = require('./player_games');
 
-module.exports = (gameCtrl) => {
+module.exports = gameCtrl => ({
+  view: vNode => m('div'),
+  oncreate: (vNode) => {
+    if (vNode.attrs.playerId === this.playerId) {
+      return;
+    }
 
+    this.playerId = atob(vNode.attrs.playerId);
+    const playerGames = PlayerGames(gameCtrl).getScrollingFinishedGamesDom(this.playerId);
 
-  return {
-    view: (vNode) => {
-      return m('div');
-    },
-    oncreate: (vNode) => {
-      if (vNode.attrs.playerId === this.playerId) {
-        return;
-      }
-
-      this.playerId = atob(vNode.attrs.playerId);
-      var playerGames = PlayerGames(gameCtrl).getScrollingFinishedGamesDom(this.playerId);
-
-      vNode.dom.appendChild(playerGames);
-    },
-    onupdate: (vNode) => {
-      /* When we arrive at this route again we need to replace the contents of
+    vNode.dom.appendChild(playerGames);
+  },
+  onupdate: (vNode) => {
+    /* When we arrive at this route again we need to replace the contents of
        * the game history page if it's a different player since we last loaded
        * this route. Maybe there's a nicer way of doing this... */
-      if (vNode.attrs.playerId !== this.playerId) {
-        this.playerId = atob(vNode.attrs.playerId);
+    if (vNode.attrs.playerId !== this.playerId) {
+      this.playerId = atob(vNode.attrs.playerId);
 
-        while (vNode.dom.firstChild) {
-          vNode.dom.removeChild(vNode.dom.firstChild);
-        }
-
-        var playerGames = PlayerGames(gameCtrl).getScrollingFinishedGamesDom(this.playerId);
-        vNode.dom.appendChild(playerGames)
+      while (vNode.dom.firstChild) {
+        vNode.dom.removeChild(vNode.dom.firstChild);
       }
 
+      const playerGames = PlayerGames(gameCtrl).getScrollingFinishedGamesDom(this.playerId);
+      vNode.dom.appendChild(playerGames);
     }
-  }
-
-}
+  },
+});

--- a/ui/recent_activity/gameEnd.js
+++ b/ui/recent_activity/gameEnd.js
@@ -21,7 +21,7 @@ module.exports = (msg, situation, myIdent) => {
       return m('div', "You lost your game against " + name);
     } else {
       var winnerName = gameState.players[gameState.status.winner].name
-      var otherPlayer = gameState.otherPlayer(gameState.status.winner).name;
+      otherPlayer = gameState.otherPlayer(gameState.status.winner).name;
       return m('div', winnerName + " won their game against " + otherPlayer);
     }
   }
@@ -36,7 +36,7 @@ module.exports = (msg, situation, myIdent) => {
       return('div', "You resigned your game against " + name)
     } else {
       var winnerName = gameState.players[gameState.status.winner].name;
-      var otherPlayer = gameState.otherPlayer(gameState.status.winner).name;
+      otherPlayer = gameState.otherPlayer(gameState.status.winner).name;
 
       return m('div', winnerName + " won their game against " + otherPlayer);
     }
@@ -52,8 +52,6 @@ module.exports = (msg, situation, myIdent) => {
     }
     else if (gameState.status.status === "resigned") {
     return m('div', {class: 'ssb-chess-game-activity-notification-text'}, renderResignMessage(gameState));
-    } else {
-
     }
   }
 
@@ -74,10 +72,6 @@ module.exports = (msg, situation, myIdent) => {
 
   return {
     view: render,
-    oncreate: () => {
-      if (situation) {
-
-      }
-    }
+    oncreate: () => {}
   }
 }

--- a/ui/recent_activity/gameEnd.js
+++ b/ui/recent_activity/gameEnd.js
@@ -1,45 +1,41 @@
-var computed = require('mutant/computed');
-var m = require('mithril');
-var resolve = require('mutant/resolve');
-var when = require('mutant/when');
+const computed = require('mutant/computed');
+const m = require('mithril');
+const resolve = require('mutant/resolve');
+const when = require('mutant/when');
 
-var Miniboard = require('../miniboard/miniboard');
+const Miniboard = require('../miniboard/miniboard');
 
 module.exports = (msg, situation, myIdent) => {
-
   function loading() {
     return m('div', 'Loading...');
   }
 
   function renderMateMessage(gameState) {
-
-    var otherPlayer = gameState.getOtherPlayer(myIdent);
-    var name = otherPlayer ? otherPlayer.name : "";
+    let otherPlayer = gameState.getOtherPlayer(myIdent);
+    const name = otherPlayer ? otherPlayer.name : '';
     if (gameState.status.winner === myIdent) {
-      return m('div', "You won your game against " + name )
-    } else if (gameState.hasPlayer(myIdent)) {
-      return m('div', "You lost your game against " + name);
-    } else {
-      var winnerName = gameState.players[gameState.status.winner].name
-      otherPlayer = gameState.otherPlayer(gameState.status.winner).name;
-      return m('div', winnerName + " won their game against " + otherPlayer);
+      return m('div', `You won your game against ${name}`);
+    } if (gameState.hasPlayer(myIdent)) {
+      return m('div', `You lost your game against ${name}`);
     }
+    const winnerName = gameState.players[gameState.status.winner].name;
+    otherPlayer = gameState.otherPlayer(gameState.status.winner).name;
+    return m('div', `${winnerName} won their game against ${otherPlayer}`);
   }
 
   function renderResignMessage(gameState) {
-    var otherPlayer = gameState.getOtherPlayer(myIdent);
-    var name = otherPlayer ? otherPlayer.name : "";
+    let otherPlayer = gameState.getOtherPlayer(myIdent);
+    const name = otherPlayer ? otherPlayer.name : '';
 
     if (gameState.status.winner === myIdent) {
-      return('div', name + " resigned their game against you.")
-    } else if (gameState.hasPlayer(myIdent)) {
-      return('div', "You resigned your game against " + name)
-    } else {
-      var winnerName = gameState.players[gameState.status.winner].name;
-      otherPlayer = gameState.otherPlayer(gameState.status.winner).name;
-
-      return m('div', winnerName + " won their game against " + otherPlayer);
+      return ('div', `${name} resigned their game against you.`);
+    } if (gameState.hasPlayer(myIdent)) {
+      return ('div', `You resigned your game against ${name}`);
     }
+    const winnerName = gameState.players[gameState.status.winner].name;
+    otherPlayer = gameState.otherPlayer(gameState.status.winner).name;
+
+    return m('div', `${winnerName} won their game against ${otherPlayer}`);
   }
 
   function renderDrawMessage(gameState) {
@@ -47,31 +43,30 @@ module.exports = (msg, situation, myIdent) => {
   }
 
   function renderInformation(gameState) {
-    if (gameState.status.status === "mate") {
-      return m('div', {class: 'ssb-chess-game-activity-notification-text'}, renderMateMessage(gameState));
+    if (gameState.status.status === 'mate') {
+      return m('div', { class: 'ssb-chess-game-activity-notification-text' }, renderMateMessage(gameState));
     }
-    else if (gameState.status.status === "resigned") {
-    return m('div', {class: 'ssb-chess-game-activity-notification-text'}, renderResignMessage(gameState));
+    if (gameState.status.status === 'resigned') {
+      return m('div', { class: 'ssb-chess-game-activity-notification-text' }, renderResignMessage(gameState));
     }
   }
 
   function render() {
     if (!situation) {
-      return loading()
-    } else {
-      var opts = {
-        small: true
-      }
-
-      return m('div', {class: "ssb-chess-game-end-notification"}, [
-        m('div', m(Miniboard(computed([situation], s=>s), situation, myIdent, opts))),
-        renderInformation(situation)
-      ]);
+      return loading();
     }
+    const opts = {
+      small: true,
+    };
+
+    return m('div', { class: 'ssb-chess-game-end-notification' }, [
+      m('div', m(Miniboard(computed([situation], s => s), situation, myIdent, opts))),
+      renderInformation(situation),
+    ]);
   }
 
   return {
     view: render,
-    oncreate: () => {}
-  }
-}
+    oncreate: () => {},
+  };
+};

--- a/ui/recent_activity/recent.js
+++ b/ui/recent_activity/recent.js
@@ -1,6 +1,6 @@
-var m = require('mithril');
-var gameEndActivity = require('./gameEnd');
-var watch = require('mutant/watch')
+const m = require('mithril');
+const watch = require('mutant/watch');
+const gameEndActivity = require('./gameEnd');
 
 /**
  * A component to render updates about chess games based on the supplied observable
@@ -22,31 +22,29 @@ var watch = require('mutant/watch')
 
  */
 module.exports = (gameCtrl, recentGameMessagesObs) => {
+  let messages = [];
+  const watches = [];
 
-  var messages = [];
-  var watches = [];
-
-  var renderers = {
-    "chess_game_end": renderGameEndMsg
-  }
+  const renderers = {
+    chess_game_end: renderGameEndMsg,
+  };
 
   function renderGameEndMsg(entry) {
     return m('div', m(gameEndActivity(entry.msg, entry.situation, gameCtrl.getMyIdent())));
   }
 
   function renderMessage(entry) {
-    var renderer = renderers[entry.msg.value.content.type];
+    const renderer = renderers[entry.msg.value.content.type];
 
     if (renderer) {
-      return m('div', {class: 'ssb-chess-game-activity-notification'}, renderer(entry));
-    } else {
-      console.log("Unexpected recent.js msg: " + entry );
-      return m('div');
+      return m('div', { class: 'ssb-chess-game-activity-notification' }, renderer(entry));
     }
+    console.log(`Unexpected recent.js msg: ${entry}`);
+    return m('div');
   }
 
   function canRender(entry) {
-    var type = entry.msg.value.content.type;
+    const type = entry.msg.value.content.type;
     return renderers.hasOwnProperty(type);
   }
 
@@ -57,24 +55,23 @@ module.exports = (gameCtrl, recentGameMessagesObs) => {
   }
 
   return {
-    view: () => m('div', {class: 'ssb-chess-game-notifications'}, renderMessages()),
+    view: () => m('div', { class: 'ssb-chess-game-notifications' }, renderMessages()),
     oncreate: () => {
-      var obs = watch(recentGameMessagesObs,
-        gameMessages => {
+      const obs = watch(recentGameMessagesObs,
+        (gameMessages) => {
           messages = gameMessages;
 
           if (messages && messages.length > 0) {
-            gameCtrl.getRecentActivityCtrl().setLastseenMessage(messages[0].msg.timestamp)  
+            gameCtrl.getRecentActivityCtrl().setLastseenMessage(messages[0].msg.timestamp);
           }
 
           m.redraw();
-        }
-      )
+        });
 
       watches.push(obs);
     },
     onremove: () => {
       watches.forEach(w => w());
-    }
-  }
-}
+    },
+  };
+};

--- a/ui/settings/settings-dialog.js
+++ b/ui/settings/settings-dialog.js
@@ -1,60 +1,59 @@
 const m = require('mithril');
 
 module.exports = (settingsCtrl, onCloseDialog) => {
-
   function labelCheckbox(label, getSetting, onSelect) {
-    var checkboxSettings = {type: 'checkbox', 'class': 'ssb-chess-dialog-checkbox', checked: getSetting(),
-    onchange: (cb) => {
-      onSelect(cb.srcElement.checked)
-    }
-  };
+    const checkboxSettings = {
+      type: 'checkbox',
+      class: 'ssb-chess-dialog-checkbox',
+      checked: getSetting(),
+      onchange: (cb) => {
+        onSelect(cb.srcElement.checked);
+      },
+    };
 
-  if (getSetting() === true) {
-    checkboxSettings['checked'] = true;
-  }
+    if (getSetting() === true) {
+      checkboxSettings.checked = true;
+    }
 
     return m('div', {
-      id: 'ssb-chess-dialog-checkbox-container'
+      id: 'ssb-chess-dialog-checkbox-container',
     }, [
-      m('span', {'class': 'ssb-chess-dialog-label'}, label),
-      m('input', checkboxSettings)
-    ])
+      m('span', { class: 'ssb-chess-dialog-label' }, label),
+      m('input', checkboxSettings),
+    ]);
   }
 
   function closeDialog() {
-      document.removeEventListener('click', windowClickListener, true);
-      onCloseDialog();
+    document.removeEventListener('click', windowClickListener, true);
+    onCloseDialog();
   }
 
   function windowClickListener(event) {
-    var dialogElement = document.getElementById('ssb-chess-settings-dialog');
+    const dialogElement = document.getElementById('ssb-chess-settings-dialog');
     if (!dialogElement) {
       return;
     }
 
-    if((event.target != dialogElement) && !dialogElement.contains(event.target) ) {
+    if ((event.target != dialogElement) && !dialogElement.contains(event.target)) {
       closeDialog();
     }
   }
 
   function closeButton() {
-    return m('button', {href: '#', 'id': 'ssb-chess-settings-dialog-close', onclick: closeDialog}, 'Close');
+    return m('button', { href: '#', id: 'ssb-chess-settings-dialog-close', onclick: closeDialog }, 'Close');
   }
 
   return {
-    view: () => {
-      return m('div', [
-        m('div', {class: 'ssb-chess-dialog-title'}, ''),
-        labelCheckbox('Move confirmation',
-         settingsCtrl.getMoveConfirmation,
-          (selected) => settingsCtrl.setMoveConfirmation(selected)),
-        labelCheckbox('Game sounds', settingsCtrl.getPlaySounds, settingsCtrl.setPlaySounds),
-        closeButton()
-      ])
-    },
+    view: () => m('div', [
+      m('div', { class: 'ssb-chess-dialog-title' }, ''),
+      labelCheckbox('Move confirmation',
+        settingsCtrl.getMoveConfirmation,
+        selected => settingsCtrl.setMoveConfirmation(selected)),
+      labelCheckbox('Game sounds', settingsCtrl.getPlaySounds, settingsCtrl.setPlaySounds),
+      closeButton(),
+    ]),
     oncreate: () => {
       document.addEventListener('click', windowClickListener, true);
-    }
-  }
-
-}
+    },
+  };
+};

--- a/ui/viewer_perspective/user_location.js
+++ b/ui/viewer_perspective/user_location.js
@@ -1,26 +1,23 @@
 module.exports = () => {
-
   /**
    * Returns true if the user can currently see the chess app, and false otherwise.
    * The user might be in a different tab in the containing application, for example.
    */
   function chessAppIsVisible() {
-    var topLevelElementArr = document.getElementsByClassName("ssb-chess-container");
+    const topLevelElementArr = document.getElementsByClassName('ssb-chess-container');
 
     if (!topLevelElementArr || topLevelElementArr.length <= 0) {
       return false;
-    } else {
-      var element = topLevelElementArr[0];
-
-      return document.hasFocus() && isVisible(element);
     }
+    const element = topLevelElementArr[0];
 
+    return document.hasFocus() && isVisible(element);
   }
 
   function isVisible(elm) {
     // Thanks https://stackoverflow.com/a/33026481 =]
-    if(!elm.offsetHeight && !elm.offsetWidth) { return false; }
-    if(getComputedStyle(elm).visibility === 'hidden') { return false; }
+    if (!elm.offsetHeight && !elm.offsetWidth) { return false; }
+    if (getComputedStyle(elm).visibility === 'hidden') { return false; }
     return true;
   }
 
@@ -35,7 +32,7 @@ module.exports = () => {
   }
 
   return {
-    chessAppIsVisible: chessAppIsVisible,
-    ifChessAppNotVisible: ifChessAppNotVisible
-  }
-}
+    chessAppIsVisible,
+    ifChessAppNotVisible,
+  };
+};


### PR DESCRIPTION
Hey @Happy0!

I thought I'd spend a few minutes to add some linting like we talked about, even if only to give you a foothold. I've got it set up like this:

- `npm test` will output any critical errors, like undefined variables
- `npm run lint` will fix any trivial issues and posts all further errors *and* warnings

The Airbnb style guide likes to call *everything* an error, so I've used `.eslintrc.js` to downgrade the majority of those to just warnings. If/when we fix those, we can remove the line from the config to upgrade it to an error. That should make future regressions easier to fight!

I've added dev dependencies from `main.js` like `electron` and `ssb-client`, but they won't be installed when ssb-chess is installed by Patchbay since they're just dev dependencies. There are still a few errors I wasn't able to resolve, maybe these are causing some of our problems? I'm especially suspicious of `PubSub`:

```console
$ npm test

> ssb-chess@2.3.2 test /home/christianbundy/Source/ssb-chess
> eslint . --quiet


/home/christianbundy/Source/ssb-chess/ctrl/game_move.js
  47:7  error  'PubSub' is not defined  no-undef

/home/christianbundy/Source/ssb-chess/main.js
  66:31  error  Unable to resolve path to module './command_line'  import/no-unresolved
  70:22  error  Unable to resolve path to module './db/init'       import/no-unresolved

/home/christianbundy/Source/ssb-chess/ui/notify/notifier.js
  10:3   error  'userGamesWatcher' is not defined  no-undef
  53:30  error  'userGamesWatcher' is not defined  no-undef

✖ 5 problems (5 errors, 0 warnings)

npm ERR! Test failed.  See above for more details.
```